### PR TITLE
docs: Make architecture docs temporal agnostic and remove redundancy

### DIFF
--- a/docs/02-architecture/00-system-map.md
+++ b/docs/02-architecture/00-system-map.md
@@ -22,38 +22,15 @@ Backcast EVS is a FastAPI-based backend implementing Entity Versioning Control S
 
 ## Key Bounded Contexts
 
-### 1. Authentication & Authorization
-**Purpose:** User identity, JWT tokens, role-based access  
-**Code:** `app/api/routes/auth.py`, `app/services/auth.py`, `app/core/security.py`  
-**Status:** ✅ Implemented
+The system is partitioned into the following bounded contexts. See [01-bounded-contexts.md](01-bounded-contexts.md) for detailed definitions, responsibilities, and interactions.
 
-### 2. User Management
-**Purpose:** CRUD for users with versioned profiles  
-**Code:** `app/api/routes/users.py`, `app/services/user.py`, `app/repositories/user.py`  
-**Versioning:** Non-branching (simple version history)  
-**Status:** ✅ Implemented
-
-### 3. Department Management  
-**Purpose:** Department entity CRUD  
-**Status:** 🔵 Planned (Story 2.2)
-
-### 4. Project & WBE Management  
-**Purpose:** Hierarchical project structure with machine tracking  
-**Versioning:** Branch-enabled (supports change orders)  
-**Status:** 📋 Backlog
-
-### 5. Cost Element & Financial Tracking  
-**Purpose:** Departmental budgets, cost registration, forecasts  
-**Versioning:** Branch-enabled  
-**Status:** 📋 Backlog
-
-### 6. Change Order & Branching  
-**Purpose:** Branch isolation, merge, comparison  
-**Status:** 📋 Backlog
-
-### 7. EVM Calculations & Reporting  
-**Purpose:** PV/EV/AC calculations, CPI/SPI metrics, variance analysis  
-**Status:** 📋 Backlog
+1.  Authentication & Authorization
+2.  User Management
+3.  Department Management
+4.  Project & WBE Management
+5.  Cost Element & Financial Tracking
+6.  Change Order & Branching
+7.  EVM Calculations & Reporting
 
 ## Versioning Architecture (EVCS Core)
 
@@ -101,21 +78,11 @@ backend/
 - **Security:** Argon2 password hashing, JWT access tokens, role-based middleware
 - **Performance:** <200ms API response target, query optimization via indexes
 
-## Current State (Sprint 2)
+## Roadmap
 
-**Completed:**
-- ✅ Infrastructure & tooling (MyPy, Ruff, pytest, CI/CD)
-- ✅ Authentication system (register, login, JWT)
-- ✅ User management (CRUD, soft delete, admin authorization)
-- ✅ Test coverage: 81.57% (39/39 tests passing)
-
-**In Progress:**
-- 🔵 Documentation restructuring
-
-**Next:**
-- 📋 Department Management (Story 2.2)
-- 📋 EVCS Core (versioning helpers, time-travel queries)
-- 📋 Project/WBE entities with branch support
+- Department Management
+- EVCS Core (versioning helpers, time-travel queries)
+- Project/WBE entities with branch support
 
 ## Key Design Decisions
 

--- a/docs/02-architecture/01-bounded-contexts.md
+++ b/docs/02-architecture/01-bounded-contexts.md
@@ -9,13 +9,6 @@ This document defines the bounded contexts used to partition the Backcast EVS sy
 ### 1. Authentication & Authorization
 **Responsibility:** User identity verification, token management, role-based access control  
 **Owner:** Backend Team  
-**Status:** ✅ Implemented  
-**Code Locations:**
-- `app/core/security.py` - Password hashing, JWT creation/decoding
-- `app/api/routes/auth.py` - Login, register, token endpoints
-- `app/api/dependencies/auth.py` - Current user dependency
-- `app/services/auth.py` - Authentication business logic
-
 **Documentation:** [contexts/auth/](contexts/auth/)
 
 ---
@@ -23,15 +16,6 @@ This document defines the bounded contexts used to partition the Backcast EVS sy
 ### 2. User Management
 **Responsibility:** User CRUD operations, profile management, admin user creation  
 **Owner:** Backend Team  
-**Status:** ✅ Implemented  
-**Code Locations:**
-- `app/models/domain/user.py` - User head + UserVersion tables
-- `app/models/schemas/user.py` - Pydantic request/response schemas
-- `app/api/routes/users.py` - User CRUD endpoints
-- `app/services/user.py` - User business logic
-- `app/repositories/user.py` - User data access
-- `app/commands/user.py` - Create/Update/Delete commands
-
 **Versioning:** Non-branching (simple version history)  
 **Documentation:** [contexts/user-management/](contexts/user-management/)
 
@@ -39,16 +23,13 @@ This document defines the bounded contexts used to partition the Backcast EVS sy
 
 ### 3. Department Management
 **Responsibility:** Department CRUD operations for budget tracking  
-**Owner:** Backend Team  
-**Status:** 📋 Planned (Story 2.2)  
-**Code Locations:** TBD
+**Owner:** Backend Team
 
 ---
 
 ### 4. Project & WBE Management
 **Responsibility:** Project hierarchy, Work Breakdown Elements (machines), revenue allocation  
 **Owner:** Backend Team  
-**Status:** 📋 Backlog  
 **Versioning:** Branch-enabled (supports change orders)
 
 ---
@@ -56,22 +37,19 @@ This document defines the bounded contexts used to partition the Backcast EVS sy
 ### 5. Cost Element & Financial Tracking
 **Responsibility:** Departmental budgets, cost registration, forecasts, earned value tracking  
 **Owner:** Backend Team  
-**Status:** 📋 Backlog  
 **Versioning:** Branch-enabled
 
 ---
 
 ### 6. Change Order Processing
 **Responsibility:** Branch creation, modification, comparison, merging  
-**Owner:** Backend Team  
-**Status:** 📋 Backlog
+**Owner:** Backend Team
 
 ---
 
 ### 7. EVM Calculations & Reporting
 **Responsibility:** Planned Value, Earned Value, Actual Cost, performance indices, variance analysis  
-**Owner:** Backend Team  
-**Status:** 📋 Backlog
+**Owner:** Backend Team
 
 ---
 

--- a/docs/02-architecture/contexts/auth/architecture.md
+++ b/docs/02-architecture/contexts/auth/architecture.md
@@ -1,7 +1,6 @@
 # Authentication Context
 
 **Last Updated:** 2025-12-29  
-**Status:** ✅ Implemented  
 **Owner:** Backend Team
 
 ## Responsibility
@@ -117,9 +116,9 @@ graph LR
 
 ## Future Enhancements
 
-- [ ] Refresh token implementation
-- [ ] Two-factor authentication (2FA)
-- [ ] OAuth2 integration (Google, GitHub)
-- [ ] Password reset flow
-- [ ] Rate limiting for auth endpoints
-- [ ] Account lockout after failed attempts
+- Refresh token implementation
+- Two-factor authentication (2FA)
+- OAuth2 integration (Google, GitHub)
+- Password reset flow
+- Rate limiting for auth endpoints
+- Account lockout after failed attempts

--- a/docs/02-architecture/contexts/user-management/architecture.md
+++ b/docs/02-architecture/contexts/user-management/architecture.md
@@ -1,7 +1,6 @@
 # User Management Context
 
 **Last Updated:** 2025-12-29  
-**Status:** ✅ Implemented  
 **Owner:** Backend Team
 
 ## Responsibility
@@ -159,20 +158,11 @@ graph TB
 
 ---
 
-## Test Coverage
-
-**API Tests:** 10 tests covering all CRUD operations, authorization rules  
-**Service Tests:** 1 test for basic CRUD flow  
-**Command Tests:** 3 tests for Create/Update/Delete commands  
-**Coverage:** 81.57% overall, UserService at 74%
-
----
-
 ## Future Enhancements
 
-- [ ] User profile photos
-- [ ] Email verification flow
-- [ ] Password reset capability
-- [ ] User preferences/settings
-- [ ] Activity log per user
-- [ ] Department hierarchy
+- User profile photos
+- Email verification flow
+- Password reset capability
+- User preferences/settings
+- Activity log per user
+- Department hierarchy


### PR DESCRIPTION
Refactors architecture documentation to focus on design rather than current implementation status.

- Removes status indicators (e.g., "Implemented", "Sprint 2", emojis).
- Removes redundant code location lists and context descriptions across files.
- Establishes `00-system-map.md` as the high-level entry point, referencing `01-bounded-contexts.md`.
- Establishes `01-bounded-contexts.md` as the registry, referencing specific context architecture files for details.
- Converts task checklists to feature roadmaps.