### PR TITLE
feat: implement progress entries UI for E05-U03

### DIFF
--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -101,6 +101,21 @@ export const queryKeys = createQueryKeys("backcast-evs", {
       ["budget-status", costElementId, context] as const,
   },
 
+  // Progress Entries
+  progressEntries: {
+    all: null as QueryKey,
+    lists: () => ["progress-entries", "list"] as const,
+    list: (costElementId: string, context?: any) =>
+      ["progress-entries", "list", costElementId, context] as const,
+    details: () => ["progress-entries", "detail"] as const,
+    detail: (id: string, context?: any) =>
+      ["progress-entries", "detail", id, context] as const,
+    history: (costElementId: string) =>
+      ["progress-entries", "history", costElementId] as const,
+    latest: (costElementId: string, context?: any) =>
+      ["progress-entries", "latest", costElementId, context] as const,
+  },
+
   // Change Orders
   changeOrders: {
     all: null as QueryKey,

--- a/frontend/src/features/progress-entries/api/useProgressEntries.ts
+++ b/frontend/src/features/progress-entries/api/useProgressEntries.ts
@@ -1,0 +1,301 @@
+import {
+  useMutation,
+  useQueryClient,
+  UseMutationOptions,
+  useQuery,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useTimeMachineParams } from "@/contexts/TimeMachineContext";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  ProgressEntriesService,
+  type ProgressEntryRead,
+  type ProgressEntryCreate,
+  type ProgressEntryUpdate,
+} from "@/api/generated";
+import type { PaginatedResponse } from "@/types/api";
+import { queryKeys } from "@/api/queryKeys";
+
+/**
+ * Progress Entry API parameters for filtering, pagination, and sorting.
+ */
+interface ProgressEntryListParams {
+  cost_element_id?: string;
+  page?: number;
+  perPage?: number;
+  asOf?: string;
+  queryOptions?: Omit<
+    UseQueryOptions<PaginatedResponse<ProgressEntryRead>>,
+    "queryKey" | "queryFn"
+  >;
+}
+
+/**
+ * Custom hook to get progress entries with pagination and filtering.
+ * Progress entries are NOT branchable but support time-travel queries.
+ */
+export const useProgressEntries = (params?: ProgressEntryListParams) => {
+  const { asOf } = useTimeMachineParams();
+
+  return useQuery<PaginatedResponse<ProgressEntryRead>>({
+    queryKey: queryKeys.progressEntries.list(
+      params?.cost_element_id || "",
+      { asOf: params?.asOf || asOf },
+    ),
+    queryFn: async () => {
+      const { cost_element_id, page = 1, perPage = 20 } = params || {};
+
+      const res = await ProgressEntriesService.getProgressEntries(
+        page,
+        perPage,
+        cost_element_id,
+        params?.asOf || asOf || undefined,
+      );
+
+      if (Array.isArray(res)) {
+        return {
+          items: res,
+          total: res.length,
+          page: 1,
+          per_page: res.length,
+        };
+      }
+      return res as unknown as PaginatedResponse<ProgressEntryRead>;
+    },
+    enabled: !!params?.cost_element_id,
+    ...params?.queryOptions,
+  });
+};
+
+/**
+ * Hook to get a single progress entry by ID.
+ * Supports time-travel queries via asOf parameter.
+ */
+export const useProgressEntry = (
+  progressEntryId: string,
+  asOf?: string,
+) => {
+  const { asOf: tmAsOf } = useTimeMachineParams();
+
+  return useQuery<ProgressEntryRead>({
+    queryKey: queryKeys.progressEntries.detail(progressEntryId, {
+      asOf: asOf || tmAsOf,
+    }),
+    queryFn: async () => {
+      return await ProgressEntriesService.getProgressEntry(
+        progressEntryId,
+        asOf || tmAsOf || undefined,
+      );
+    },
+    enabled: !!progressEntryId,
+  });
+};
+
+/**
+ * Hook to get the latest progress entry for a cost element.
+ * Supports time-travel queries via asOf parameter.
+ */
+export const useLatestProgress = (
+  costElementId: string,
+  asOf?: string,
+) => {
+  const { asOf: tmAsOf } = useTimeMachineParams();
+
+  return useQuery<ProgressEntryRead | null>({
+    queryKey: queryKeys.progressEntries.latest(costElementId, {
+      asOf: asOf || tmAsOf,
+    }),
+    queryFn: async () => {
+      return await ProgressEntriesService.getLatestProgress(
+        costElementId,
+        asOf || tmAsOf || undefined,
+      );
+    },
+    enabled: !!costElementId,
+    staleTime: 60000, // Consider fresh for 1 minute
+  });
+};
+
+/**
+ * Hook to get progress history for a cost element.
+ * Returns all progress entries ordered by reported_date descending.
+ */
+export const useProgressHistory = (
+  costElementId: string,
+  page: number = 1,
+  perPage: number = 20,
+) => {
+  return useQuery<PaginatedResponse<ProgressEntryRead>>({
+    queryKey: queryKeys.progressEntries.history(costElementId),
+    queryFn: async () => {
+      const res = await ProgressEntriesService.getProgressHistory(
+        costElementId,
+        page,
+        perPage,
+      );
+
+      if (Array.isArray(res)) {
+        return {
+          items: res,
+          total: res.length,
+          page: 1,
+          per_page: res.length,
+        };
+      }
+      return res as unknown as PaginatedResponse<ProgressEntryRead>;
+    },
+    enabled: !!costElementId,
+  });
+};
+
+/**
+ * Custom create hook for progress entries.
+ * Progress entries are NOT branchable (global facts).
+ * Uses the current user from auth context for reported_by_user_id.
+ */
+export const useCreateProgressEntry = (
+  mutationOptions?: Omit<
+    UseMutationOptions<ProgressEntryRead, Error, ProgressEntryCreate>,
+    "mutationFn"
+  >,
+) => {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+
+  return useMutation<ProgressEntryRead, Error, ProgressEntryCreate>({
+    mutationFn: (data: ProgressEntryCreate) => {
+      // Auto-inject reported_by_user_id from current user
+      const payload: ProgressEntryCreate = {
+        ...data,
+        reported_by_user_id: user?.user_id || "",
+      };
+      return ProgressEntriesService.createProgressEntry(payload);
+    },
+    onSuccess: (data, variables) => {
+      // Invalidate related queries
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.progressEntries.all,
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.progressEntries.latest(variables.cost_element_id, {}),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.costElements.evmMetrics(variables.cost_element_id, {}),
+      });
+      toast.success("Progress entry created successfully");
+      mutationOptions?.onSuccess?.(data, variables, undefined);
+    },
+    onError: (error, ...args) => {
+      toast.error(`Error creating progress entry: ${error.message}`);
+      mutationOptions?.onError?.(error, ...args);
+    },
+    ...mutationOptions,
+  });
+};
+
+/**
+ * Custom update hook for progress entries.
+ * Creates a new version of the progress entry with updated values.
+ * Includes optimistic updates with rollback on error.
+ */
+export const useUpdateProgressEntry = (
+  mutationOptions?: Omit<
+    UseMutationOptions<
+      ProgressEntryRead,
+      Error,
+      { id: string; data: ProgressEntryUpdate },
+      { previousEntry?: ProgressEntryRead }
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { asOf } = useTimeMachineParams();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    ProgressEntryRead,
+    Error,
+    { id: string; data: ProgressEntryUpdate },
+    { previousEntry?: ProgressEntryRead }
+  >({
+    mutationFn: ({ id, data }: { id: string; data: ProgressEntryUpdate }) => {
+      return ProgressEntriesService.updateProgressEntry(id, data);
+    },
+    onMutate: async ({ id, data }) => {
+      // Cancel outgoing refetches
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.progressEntries.detail(id, { asOf }),
+      });
+      await queryClient.cancelQueries({
+        queryKey: queryKeys.progressEntries.lists(),
+      });
+
+      // Snapshot previous value
+      const previousEntry = queryClient.getQueryData(
+        queryKeys.progressEntries.detail(id, { asOf }),
+      );
+
+      // Optimistically update
+      if (previousEntry) {
+        queryClient.setQueryData(
+          queryKeys.progressEntries.detail(id, { asOf }),
+          (old: ProgressEntryRead) => ({
+            ...old,
+            ...data,
+          }),
+        );
+      }
+
+      return { previousEntry };
+    },
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.progressEntries.all,
+      });
+      toast.success("Progress entry updated successfully");
+      mutationOptions?.onSuccess?.(...args);
+    },
+    onError: (error, variables, context) => {
+      // Rollback
+      if (context?.previousEntry) {
+        queryClient.setQueryData(
+          queryKeys.progressEntries.detail(variables.id, { asOf }),
+          context.previousEntry,
+        );
+      }
+      toast.error(`Error updating progress entry: ${error.message}`);
+      mutationOptions?.onError?.(error, variables, context, undefined);
+    },
+    ...mutationOptions,
+  });
+};
+
+/**
+ * Custom delete hook for progress entries.
+ * Soft deletes the progress entry (preserves in history).
+ * Includes confirmation modal via App.useApp().
+ */
+export const useDeleteProgressEntry = (
+  mutationOptions?: Omit<UseMutationOptions<void, Error, string>, "mutationFn">,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (progressEntryId: string) => {
+      return ProgressEntriesService.deleteProgressEntry(progressEntryId);
+    },
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.progressEntries.all,
+      });
+      toast.success("Progress entry deleted successfully");
+      mutationOptions?.onSuccess?.(...args);
+    },
+    onError: (error, ...args) => {
+      toast.error(`Error deleting progress entry: ${error.message}`);
+      mutationOptions?.onError?.(error, ...args);
+    },
+    ...mutationOptions,
+  });
+};

--- a/frontend/src/features/progress-entries/components/ProgressEntriesTab.tsx
+++ b/frontend/src/features/progress-entries/components/ProgressEntriesTab.tsx
@@ -1,0 +1,417 @@
+import { App, Button, Space, Input, Card, Progress, Alert, Tooltip } from "antd";
+import {
+  DeleteOutlined,
+  EditOutlined,
+  PlusOutlined,
+  HistoryOutlined,
+  SearchOutlined,
+} from "@ant-design/icons";
+import { useState } from "react";
+import type { ColumnType } from "antd/es/table";
+import type { FilterValue } from "antd/es/table/interface";
+import type { CostElementRead } from "@/api/generated";
+import type {
+  ProgressEntryRead,
+  ProgressEntryCreate,
+} from "@/api/generated";
+import {
+  useProgressEntries,
+  useCreateProgressEntry,
+  useUpdateProgressEntry,
+  useDeleteProgressEntry,
+} from "../api/useProgressEntries";
+import { ProgressEntryModal } from "./ProgressEntryModal";
+import { StandardTable } from "@/components/common/StandardTable";
+import { useTableParams } from "@/hooks/useTableParams";
+import { Can } from "@/components/auth/Can";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/api/queryKeys";
+import dayjs from "dayjs";
+import { useEntityHistory } from "@/hooks/useEntityHistory";
+import { VersionHistoryDrawer } from "@/components/common/VersionHistory";
+import { ProgressEntriesService } from "@/api/generated";
+
+interface ProgressEntriesTabProps {
+  costElement: CostElementRead;
+}
+
+interface ProgressEntryApiParams {
+  cost_element_id?: string;
+  page?: number;
+  perPage?: number;
+  asOf?: string;
+}
+
+/**
+ * Progress Entries Tab Component
+ *
+ * Displays progress entries for a cost element with:
+ * - Latest progress summary card
+ * - Progress visualization
+ * - Paginated history table
+ * - CRUD operations
+ */
+export const ProgressEntriesTab = ({
+  costElement,
+}: ProgressEntriesTabProps) => {
+  const { tableParams, handleTableChange, handleSearch } = useTableParams<
+    ProgressEntryRead,
+    Record<string, FilterValue | null>
+  >();
+  const queryClient = useQueryClient();
+
+  // Build query params
+  const queryParams: ProgressEntryApiParams = {
+    cost_element_id: costElement.cost_element_id,
+    page: tableParams.pagination?.current || 1,
+    perPage: tableParams.pagination?.pageSize || 10,
+  };
+
+  const { data, isLoading, refetch } = useProgressEntries(queryParams);
+  const progressEntries = data?.items || [];
+  const total = data?.total || 0;
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selectedEntry, setSelectedEntry] = useState<ProgressEntryRead | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  // History hook
+  const { data: historyVersions, isLoading: historyLoading } = useEntityHistory({
+    resource: "progress_entries",
+    entityId: selectedEntry?.progress_entry_id,
+    fetchFn: (id) => ProgressEntriesService.getProgressEntryHistory(id),
+    enabled: historyOpen,
+  });
+
+  const { mutateAsync: createProgressEntry } = useCreateProgressEntry({
+    onSuccess: () => {
+      refetch();
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.costElements.evmMetrics(costElement.cost_element_id),
+      });
+      setModalOpen(false);
+    },
+  });
+
+  const { mutateAsync: updateProgressEntry } = useUpdateProgressEntry({
+    onSuccess: () => {
+      refetch();
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.costElements.evmMetrics(costElement.cost_element_id),
+      });
+      setModalOpen(false);
+    },
+  });
+
+  const { mutate: deleteProgressEntry } = useDeleteProgressEntry({
+    onSuccess: () => {
+      refetch();
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.costElements.evmMetrics(costElement.cost_element_id),
+      });
+    },
+  });
+
+  const { modal } = App.useApp();
+
+  const handleDelete = (id: string) => {
+    modal.confirm({
+      title: "Are you sure you want to delete this Progress Entry?",
+      content:
+        "This will soft delete the progress entry. It will be preserved in history.",
+      okText: "Yes, Delete",
+      okType: "danger",
+      onOk: () => deleteProgressEntry(id),
+    });
+  };
+
+  const getColumnSearchProps = (
+    dataIndex: keyof ProgressEntryRead,
+  ): ColumnType<ProgressEntryRead> => ({
+    filterDropdown: ({
+      setSelectedKeys,
+      selectedKeys,
+      confirm,
+      clearFilters,
+    }) => (
+      <div style={{ padding: 8 }}>
+        <Input
+          placeholder={`Search ${dataIndex}`}
+          value={selectedKeys[0]}
+          onChange={(e) =>
+            setSelectedKeys(e.target.value ? [e.target.value] : [])
+          }
+          onPressEnter={() => confirm()}
+          style={{ width: 188, marginBottom: 8, display: "block" }}
+        />
+        <Space>
+          <Button
+            type="primary"
+            onClick={() => confirm()}
+            icon={<SearchOutlined />}
+            size="small"
+            style={{ width: 90 }}
+          >
+            Search
+          </Button>
+          <Button
+            onClick={() => clearFilters && clearFilters()}
+            size="small"
+            style={{ width: 90 }}
+          >
+            Reset
+          </Button>
+        </Space>
+      </div>
+    ),
+    filterIcon: (filtered: boolean) => (
+      <SearchOutlined style={{ color: filtered ? "#1890ff" : undefined }} />
+    ),
+    onFilter: (value, record) => {
+      const fieldVal = record[dataIndex];
+      return fieldVal
+        ? fieldVal
+            .toString()
+            .toLowerCase()
+            .includes((value as string).toLowerCase())
+        : false;
+    },
+  });
+
+  const columns: ColumnType<ProgressEntryRead>[] = [
+    {
+      title: "Reported Date",
+      dataIndex: "reported_date",
+      key: "reported_date",
+      sorter: true,
+      render: (date) => (date ? dayjs(date).format("YYYY-MM-DD HH:mm") : "-"),
+    },
+    {
+      title: "Progress",
+      dataIndex: "progress_percentage",
+      key: "progress_percentage",
+      sorter: true,
+      render: (percentage) => {
+        const value = parseFloat(percentage);
+        return (
+          <Space>
+            <span>{value.toFixed(2)}%</span>
+            <Progress
+              percent={value}
+              size="small"
+              status={value === 100 ? "success" : "active"}
+              style={{ width: 80 }}
+            />
+          </Space>
+        );
+      },
+    },
+    {
+      title: "Notes",
+      dataIndex: "notes",
+      key: "notes",
+      ...getColumnSearchProps("notes"),
+      render: (notes) => {
+        if (!notes) return "-";
+        const truncated = notes.length > 50 ? notes.slice(0, 50) + "..." : notes;
+        return notes.length > 50 ? (
+          <Tooltip title={notes}>
+            <span>{truncated}</span>
+          </Tooltip>
+        ) : (
+          <span>{notes}</span>
+        );
+      },
+    },
+    {
+      title: "Reported By",
+      dataIndex: "created_by",
+      key: "created_by",
+      render: (name) => name || "-",
+    },
+    {
+      title: "Actions",
+      key: "actions",
+      render: (_, record) => (
+        <Space>
+          <Can permission="progress-entry-read">
+            <Button
+              icon={<HistoryOutlined />}
+              onClick={() => {
+                setSelectedEntry(record);
+                setHistoryOpen(true);
+              }}
+              title="View History"
+            />
+          </Can>
+          <Can permission="progress-entry-update">
+            <Button
+              icon={<EditOutlined />}
+              onClick={() => {
+                setSelectedEntry(record);
+                setModalOpen(true);
+              }}
+              title="Edit"
+            />
+          </Can>
+          <Can permission="progress-entry-delete">
+            <Button
+              danger
+              icon={<DeleteOutlined />}
+              onClick={() => handleDelete(record.progress_entry_id)}
+              title="Delete"
+            />
+          </Can>
+        </Space>
+      ),
+    },
+  ];
+
+  // Latest progress (first entry since API returns in descending order)
+  const latestProgress = progressEntries[0];
+
+  return (
+    <div>
+      <Space direction="vertical" style={{ width: "100%" }} size="large">
+        {/* Latest Progress Summary */}
+        {latestProgress && (
+          <Card>
+            <Space direction="vertical" style={{ width: "100%" }}>
+              <div style={{ display: "flex", justifyContent: "space-between" }}>
+                <span style={{ fontWeight: "bold" }}>Latest Progress:</span>
+                <span>
+                  {dayjs(latestProgress.reported_date).format("MMM D, YYYY HH:mm")}
+                </span>
+              </div>
+              <div>
+                <Progress
+                  percent={parseFloat(latestProgress.progress_percentage)}
+                  status={parseFloat(latestProgress.progress_percentage) === 100 ? "success" : "active"}
+                />
+              </div>
+              {latestProgress.notes && (
+                <Alert
+                  message={latestProgress.notes}
+                  type="info"
+                  style={{ fontSize: "12px" }}
+                />
+              )}
+            </Space>
+          </Card>
+        )}
+
+        {!latestProgress && (
+          <Alert
+            message="No progress recorded yet"
+            description="Click 'Add Progress' to record the first progress entry for this cost element."
+            type="info"
+            showIcon
+          />
+        )}
+
+        {/* Progress Entries Table */}
+        <StandardTable<ProgressEntryRead>
+          tableParams={{
+            ...tableParams,
+            pagination: { ...tableParams.pagination, total },
+          }}
+          onChange={handleTableChange}
+          loading={isLoading}
+          dataSource={progressEntries}
+          columns={columns}
+          rowKey="progress_entry_id"
+          searchable={true}
+          searchPlaceholder="Search progress entries..."
+          onSearch={handleSearch}
+          toolbar={
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                width: "100%",
+              }}
+            >
+              <div style={{ fontSize: "16px", fontWeight: "bold" }}>
+                Progress History
+              </div>
+
+              <Can permission="progress-entry-create">
+                <Button
+                  type="primary"
+                  icon={<PlusOutlined />}
+                  onClick={() => {
+                    setSelectedEntry(null);
+                    setModalOpen(true);
+                  }}
+                >
+                  Add Progress
+                </Button>
+              </Can>
+            </div>
+          }
+        />
+      </Space>
+
+      {/* Create/Edit Modal */}
+      <ProgressEntryModal
+        open={modalOpen}
+        onCancel={() => setModalOpen(false)}
+        onOk={async (values) => {
+          if (selectedEntry) {
+            await updateProgressEntry({
+              id: selectedEntry.progress_entry_id,
+              data: values,
+            });
+          } else {
+            await createProgressEntry(values as ProgressEntryCreate);
+          }
+        }}
+        confirmLoading={isLoading}
+        initialValues={selectedEntry}
+        costElementId={costElement.cost_element_id}
+      />
+
+      {/* History Drawer */}
+      <VersionHistoryDrawer
+        open={historyOpen}
+        onClose={() => setHistoryOpen(false)}
+        versions={(historyVersions || []).map((version, idx, arr) => {
+          type HistoryItem = {
+            valid_from?: string;
+            valid_time?: string | { lower: string };
+            transaction_time?: string | { lower: string };
+            created_by_name?: string;
+            progress_percentage?: string;
+          };
+          const v = version as unknown as HistoryItem;
+
+          return {
+            id: `v${arr.length - idx}`,
+            valid_from:
+              v.valid_from ||
+              (typeof v.valid_time === "object" ? v.valid_time?.lower : null) ||
+              (typeof v.valid_time === "string"
+                ? v.valid_time
+                : new Date().toISOString()),
+            transaction_time:
+              (typeof v.transaction_time === "object"
+                ? v.transaction_time?.lower
+                : null) ||
+              (typeof v.transaction_time === "string"
+                ? v.transaction_time
+                : new Date().toISOString()),
+            changed_by: v.created_by_name || "System",
+            changes: idx === 0 ? { created: "initial" } : { updated: "changed" },
+          };
+        })}
+        entityName={`Progress Entry: ${
+          selectedEntry?.progress_percentage
+            ? `${selectedEntry.progress_percentage}%`
+            : "Progress"
+        }`}
+        isLoading={historyLoading}
+      />
+    </div>
+  );
+};

--- a/frontend/src/features/progress-entries/components/ProgressEntryModal.tsx
+++ b/frontend/src/features/progress-entries/components/ProgressEntryModal.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { Modal, Form, InputNumber, DatePicker, Input, Alert, Space } from "antd";
+import type {
+  ProgressEntryRead,
+  ProgressEntryCreate,
+  ProgressEntryUpdate,
+} from "@/api/generated";
+import { useLatestProgress } from "../api/useProgressEntries";
+import dayjs from "dayjs";
+
+interface ProgressEntryModalProps {
+  open: boolean;
+  onCancel: () => void;
+  onOk: (values: ProgressEntryCreate | ProgressEntryUpdate) => void;
+  confirmLoading: boolean;
+  initialValues?: ProgressEntryRead | null;
+  costElementId: string;
+}
+
+/**
+ * Modal form for creating/updating progress entries.
+ *
+ * Features:
+ * - Progress percentage validation (0-100, 2 decimals)
+ * - Date picker with time support
+ * - Notes field (optional, but recommended when progress decreases)
+ * - Warning display when progress decreases from latest
+ */
+export const ProgressEntryModal = ({
+  open,
+  onCancel,
+  onOk,
+  confirmLoading,
+  initialValues,
+  costElementId,
+}: ProgressEntryModalProps) => {
+  const [form] = Form.useForm();
+  const isEdit = !!initialValues;
+
+  // Get latest progress for comparison (to warn on decreases)
+  const { data: latestProgress } = useLatestProgress(costElementId);
+
+  // Track decrease warning state
+  const [showDecreaseWarning, setShowDecreaseWarning] = useState(false);
+
+  // Set initial form values
+  const initialValuesForForm = initialValues
+    ? {
+        progress_percentage: parseFloat(initialValues.progress_percentage),
+        reported_date: dayjs(initialValues.reported_date),
+        notes: initialValues.notes || "",
+      }
+    : {
+        reported_date: dayjs(),
+      };
+
+  // Check if progress is decreasing
+  const checkProgressDecrease = (value: number | null) => {
+    if (value === null || value === undefined) {
+      setShowDecreaseWarning(false);
+      return;
+    }
+
+    // Show warning if new progress is less than latest (only for create mode)
+    if (!isEdit && latestProgress && value < parseFloat(latestProgress.progress_percentage)) {
+      setShowDecreaseWarning(true);
+    } else {
+      setShowDecreaseWarning(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const values = await form.validateFields();
+
+      // Format the data for API
+      const formattedValues: ProgressEntryCreate | ProgressEntryUpdate = {
+        progress_percentage: values.progress_percentage,
+        reported_date: values.reported_date.toISOString(),
+        notes: values.notes || null,
+      };
+
+      // Add cost_element_id for create only
+      if (!isEdit) {
+        (formattedValues as ProgressEntryCreate).cost_element_id = costElementId;
+        // Note: reported_by_user_id is auto-injected in the API hook
+      }
+
+      await onOk(formattedValues);
+    } catch (error) {
+      console.error("Form submission error:", error);
+    }
+  };
+
+  return (
+    <Modal
+      title={isEdit ? "Edit Progress Entry" : "Record Progress"}
+      open={open}
+      onCancel={onCancel}
+      onOk={handleSubmit}
+      okText={isEdit ? "Save" : "Record"}
+      confirmLoading={confirmLoading}
+      destroyOnClose
+      width={600}
+    >
+      <Form
+        form={form}
+        layout="vertical"
+        name="progress_entry_form"
+        initialValues={initialValuesForForm}
+      >
+        {showDecreaseWarning && (
+          <Alert
+            message="Progress Decrease Detected"
+            description="You are recording a decrease in progress. Please add notes explaining why this has occurred."
+            type="warning"
+            showIcon
+            style={{ marginBottom: 16 }}
+          />
+        )}
+
+        <Form.Item
+          name="progress_percentage"
+          label="Progress Percentage"
+          rules={[
+            { required: true, message: "Please enter progress percentage" },
+            {
+              type: "number",
+              min: 0,
+              max: 100,
+              message: "Progress must be between 0 and 100",
+            },
+          ]}
+        >
+          <InputNumber
+            style={{ width: "100%" }}
+            min={0}
+            max={100}
+            step={0.01}
+            precision={2}
+            formatter={(value) => `${value}%`}
+            parser={(value) =>
+              value?.replace("%", "") as unknown as number
+            }
+            onChange={checkProgressDecrease}
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="reported_date"
+          label="Reported Date"
+          rules={[{ required: true, message: "Please select a date and time" }]}
+        >
+          <DatePicker
+            showTime
+            style={{ width: "100%" }}
+            format="YYYY-MM-DD HH:mm"
+            placeholder="Select date and time"
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="notes"
+          label="Notes"
+          tooltip={
+            showDecreaseWarning
+              ? "Recommended: explain why progress decreased"
+              : "Optional: add context about this progress entry"
+          }
+        >
+          <Input.TextArea
+            placeholder={
+              showDecreaseWarning
+                ? "Please explain why progress has decreased..."
+                : "Add notes (optional)"
+            }
+            rows={3}
+            maxLength={1000}
+            showCount
+          />
+        </Form.Item>
+
+        {latestProgress && !isEdit && (
+          <Alert
+            message={
+              <Space>
+                <span>Latest Progress: </span>
+                <strong>{latestProgress.progress_percentage}%</strong>
+                <span>
+                  ({dayjs(latestProgress.reported_date).format("YYYY-MM-DD HH:mm")})
+                </span>
+              </Space>
+            }
+            type="info"
+            showIcon
+          />
+        )}
+      </Form>
+    </Modal>
+  );
+};

--- a/frontend/src/features/progress-entries/index.ts
+++ b/frontend/src/features/progress-entries/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Progress Entries Feature
+ *
+ * Exports all progress entry related components and hooks.
+ *
+ * @example
+ * ```tsx
+ * import { ProgressEntriesTab, useProgressEntries } from '@/features/progress-entries';
+ * ```
+ */
+
+// API Hooks
+export * from './api/useProgressEntries';
+
+// Components
+export * from './components/ProgressEntryModal';
+export * from './components/ProgressEntriesTab';

--- a/frontend/src/pages/cost-elements/CostElementDetailPage.tsx
+++ b/frontend/src/pages/cost-elements/CostElementDetailPage.tsx
@@ -9,6 +9,7 @@ import { OverviewTab } from "./tabs/OverviewTab";
 import { CostRegistrationsTab } from "./tabs/CostRegistrationsTab";
 import { ForecastsTab } from "./tabs/ForecastsTab";
 import { ScheduleBaselinesTab } from "./tabs/ScheduleBaselinesTab";
+import { ProgressEntriesTab } from "@/features/progress-entries/components/ProgressEntriesTab";
 import {
   CostElementBreadcrumbBuilder,
   type CostElementBreadcrumb,
@@ -72,6 +73,13 @@ export const CostElementDetailPage = () => {
       label: "Cost Registrations",
       children: costElement ? (
         <CostRegistrationsTab costElement={costElement} />
+      ) : null,
+    },
+    {
+      key: "progress",
+      label: "Progress",
+      children: costElement ? (
+        <ProgressEntriesTab costElement={costElement} />
       ) : null,
     },
   ];


### PR DESCRIPTION
Implement frontend UI for recording and managing progress entries (earned value % complete) for cost elements.

Features:
- Progress entry list with pagination and search
- Create/update modal with validation (0-100%)
- Progress decrease warning with notes recommendation
- Version history support
- Permission-based actions
- Time Machine integration for time-travel queries
- Optimistic updates with rollback

Files:
- frontend/src/features/progress-entries/api/useProgressEntries.ts
- frontend/src/features/progress-entries/components/ProgressEntryModal.tsx
- frontend/src/features/progress-entries/components/ProgressEntriesTab.tsx
- frontend/src/features/progress-entries/index.ts
- frontend/src/api/queryKeys.ts (added progress entries keys)
- frontend/src/pages/cost-elements/CostElementDetailPage.tsx (added Progress tab)