### PR TITLE
feat: enhance EVM S-curve with 4 metrics and time machine support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Tech Stack:** Python 3.12+ / FastAPI (backend) + React 18 / TypeScript / Vite (frontend) + PostgreSQL 15+
 
-**Architecture Docs:** See @docs/02-architecture for detailed architecture and @docs/02-architecture/backend/coding-standards.md and @docs/02-architecture/frontend/coding-standards.md for coding standards.
-
 ## Common Commands
 
 ### Backend (Python/FastAPI)
@@ -57,11 +55,11 @@ npm run lint                   # ESLint - must pass
 
 ## Architecture Overview
 
-**Backend:** Layered architecture (API → Services → Repositories → Models). See @docs/02-architecture/00-system-map.md
+**Backend:** Layered architecture (API → Services → Repositories → Models).
 
-**Frontend:** Feature-based organization with TanStack Query for server state, Zustand for client state. See @docs/02-architecture/frontend/contexts/01-core-architecture.md
+**Frontend:** Feature-based organization with TanStack Query for server state, Zustand for client state.
 
-**EVCS (Entity Versioning Control System):** Bitemporal versioning with PostgreSQL TSTZRANGE. All versioned entities support branch isolation for change orders. See @backend/app/core/versioning/
+**EVCS (Entity Versioning Control System):** Bitemporal versioning with PostgreSQL TSTZRANGE. All versioned entities support branch isolation for change orders.
 
 ## Database Strategy
 
@@ -92,15 +90,8 @@ npm run lint                   # ESLint - must pass
 - **Non-versioned entities:** Use `SimpleBase`, `SimpleService` (standard CRUD, standard delete)
 - **Key files:** `backend/app/core/versioning/temporal.py`, `backend/app/core/versioning/simple.py`
 
-**Bounded Contexts:** Auth, User Mgmt, Dept Mgmt, Project/WBE, Cost Elements, Change Orders, EVM. See @docs/02-architecture/01-bounded-contexts.md
-
-<<<<<<< HEAD
 ## Documentation
 
-- [Documentation Guide](docs/00-meta/README.md)
+- see [Documentation Guide](docs/00-meta/README.md)
 - [System Architecture and Coding Standards](docs/02-architecture/README.md)
-=======
-**Documentation:**
-- Architecture: @docs/02-architecture
-- Product Scope: @docs/01-product-scope
->>>>>>> a11c273 (docs: Update CLAUDE.md and coding standards)
+

--- a/backend/EV_INVESTIGATION_REPORT.md
+++ b/backend/EV_INVESTIGATION_REPORT.md
@@ -1,0 +1,222 @@
+# EV S-Curve Bug Investigation Report
+
+**Date:** 2026-02-11  
+**Issue:** EV (Earned Value) S-curve always shows 0 values in impact analysis  
+**Project:** PRJ-DEMO-002 (ID: `877c4cba-b30e-54c1-b25d-c73fb364019d`)  
+**Change Order:** CO-2026-007 (Branch: `BR-CO-2026-007`)
+
+---
+
+## Executive Summary
+
+**ROOT CAUSE:** The EV S-curve shows 0 values because **PRJ-DEMO-002 has no ProgressEntry records** in the database. The EV calculation correctly returns 0 when there is no progress data, which is the expected behavior.
+
+**NOT A BUG:** This is working as designed. The EV formula is:
+```
+EV = budget_allocation × progress_percentage / 100
+```
+
+Without progress entries, `progress_percentage` is undefined/null, resulting in EV = 0.
+
+---
+
+## Investigation Findings
+
+### 1. Database State
+
+#### ProgressEntry Records in Database:
+- **Total ProgressEntry records:** 285
+- **Project with progress entries:** Demo Project 1 (ID: `d54fbbe6-f3df-51db-9c3e-9408700442be`)
+- **PRJ-DEMO-002 progress entries:** **0**
+
+#### CostElements in PRJ-DEMO-002:
+- **Total CostElements:** 50 (25 on main branch, 25 on `BR-CO-2026-007`)
+- **CostElements with progress:** 0
+- **CostElements without progress:** 50
+
+### 2. Code Analysis
+
+The EV calculation logic in `/home/nicola/dev/backcast_evs/backend/app/services/impact_analysis_service.py` (lines 1227-1232) is **CORRECT**:
+
+```python
+# EV: Use progress entries
+pe = progress_lookup.get((ce.cost_element_id, "main"))
+if pe:
+    ev = budget * pe.progress_percentage / Decimal("100")
+    main_ev += ev
+# If no progress entry, EV = 0  ← CORRECT BEHAVIOR
+```
+
+The code:
+1. Looks up progress entries from the database
+2. Calculates EV as `budget × progress_percentage / 100`
+3. Adds to accumulated EV if progress entry exists
+4. **Correctly adds 0 if no progress entry exists** (the commented line shows this is intentional)
+
+### 3. Why EV is 0 - Step by Step
+
+1. **Query for progress entries** (line 1099-1116):
+   ```python
+   progress_stmt = (
+       select(ProgressEntry, CostElement)
+       .join(CostElement, ProgressEntry.cost_element_id == CostElement.cost_element_id)
+       .join(WBE, CostElement.wbe_id == WBE.wbe_id)
+       .where(
+           WBE.project_id == PROJECT_ID,  # ← Filters for PRJ-DEMO-002
+           CostElement.branch.in_(["main", BRANCH_NAME]),
+           # ... other filters
+       )
+   )
+   ```
+   Result: **0 rows** because PRJ-DEMO-002 has no progress entries
+
+2. **Build progress lookup** (line 1118-1124):
+   ```python
+   progress_lookup: dict[tuple[UUID, str], ProgressEntry] = {}
+   for pe, ce in progress_rows:  # ← progress_rows is empty
+       key = (ce.cost_element_id, ce.branch)
+       if key not in progress_lookup:
+           progress_lookup[key] = pe
+   ```
+   Result: **Empty dictionary** `{}`
+
+3. **Calculate EV for each week** (line 1228-1231):
+   ```python
+   pe = progress_lookup.get((ce.cost_element_id, "main"))  # ← Returns None
+   if pe:  # ← Condition is False
+       ev = budget * pe.progress_percentage / Decimal("100")
+       main_ev += ev
+   # main_ev remains 0
+   ```
+   Result: **EV = 0** for all weeks
+
+---
+
+## Verification
+
+### SQL Queries Run
+
+1. **Count ProgressEntry for PRJ-DEMO-002:**
+   ```sql
+   SELECT COUNT(*) 
+   FROM progress_entries pe
+   JOIN cost_elements ce ON pe.cost_element_id = ce.cost_element_id
+   JOIN wbes ON ce.wbe_id = wbes.wbe_id
+   WHERE wbes.project_id = '877c4cba-b30e-54c1-b25d-c73fb364019d'
+     AND pe.deleted_at IS NULL
+     AND upper(pe.valid_time) IS NULL;
+   ```
+   **Result:** 0
+
+2. **Count CostElements for PRJ-DEMO-002:**
+   ```sql
+   SELECT COUNT(*), ce.branch
+   FROM cost_elements ce
+   JOIN wbes ON ce.wbe_id = wbes.wbe_id
+   WHERE wbes.project_id = '877c4cba-b30e-54c1-b25d-c73fb364019d'
+     AND ce.deleted_at IS NULL
+     AND upper(ce.valid_time) IS NULL
+   GROUP BY ce.branch;
+   ```
+   **Result:** 
+   - main: 25
+   - BR-CO-2026-007: 25
+
+3. **Check which project has progress entries:**
+   ```sql
+   SELECT p.name, COUNT(*) as progress_count
+   FROM progress_entries pe
+   JOIN cost_elements ce ON pe.cost_element_id = ce.cost_element_id
+   JOIN wbes ON ce.wbe_id = wbes.wbe_id
+   JOIN projects p ON wbes.project_id = p.project_id
+   WHERE pe.deleted_at IS NULL
+     AND upper(pe.valid_time) IS NULL
+   GROUP BY p.name, p.project_id;
+   ```
+   **Result:** Demo Project 1: 285 progress entries
+
+---
+
+## Solutions
+
+### Option 1: Add Progress Entry Data (Recommended for Testing)
+
+To see non-zero EV values, you need to create progress entries for PRJ-DEMO-002:
+
+```python
+from datetime import datetime, UTC
+from decimal import Decimal
+from uuid import uuid4
+
+from app.db.session import async_session_maker
+from app.models.domain.progress_entry import ProgressEntry
+
+async def create_test_progress():
+    async with async_session_maker() as session:
+        # Create progress entries for cost elements
+        # Replace cost_element_id with actual IDs from PRJ-DEMO-002
+        pe = ProgressEntry(
+            progress_entry_id=uuid4(),
+            cost_element_id="2b5d4292-27cb-591c-92e4-e586e02a9de4",  # Example CE ID
+            progress_percentage=Decimal("50.00"),  # 50% complete
+            valid_time="(datetime(2026, 1, 15, tzinfo=UTC),)",
+            transaction_time="(datetime(2026, 1, 15, tzinfo=UTC),)",
+            created_by=uuid4(),
+        )
+        session.add(pe)
+        await session.commit()
+```
+
+### Option 2: Update UI to Handle Missing Data
+
+Update the S-curve component to show a message when EV is 0 due to missing progress:
+
+```typescript
+if (evData.every(point => point.mainValue === 0 && point.changeValue === 0)) {
+  return (
+    <Alert 
+      message="No Progress Data" 
+      description="Earned Value requires progress entries. Please add progress data for cost elements." 
+      type="info" 
+    />
+  );
+}
+```
+
+### Option 3: Use Test Data with Existing Progress
+
+Use "Demo Project 1" for testing instead of PRJ-DEMO-002, since it has 285 progress entries.
+
+---
+
+## Conclusion
+
+**The EV S-curve is working correctly.** The 0 values are due to missing ProgressEntry data for PRJ-DEMO-002, not a code bug.
+
+### Impact Analysis Service Code Status:
+- ✅ Progress entry query is correct
+- ✅ Progress lookup logic is correct
+- ✅ EV calculation formula is correct
+- ✅ Handling of missing progress is correct (EV = 0)
+
+### Data Status:
+- ❌ PRJ-DEMO-002 has no progress entries
+- ✅ Demo Project 1 has 285 progress entries
+
+### Recommended Actions:
+1. **For testing:** Use Demo Project 1 or create progress entries for PRJ-DEMO-002
+2. **For production:** Add progress entry creation to the project setup workflow
+3. **For UX:** Add UI indicators when progress data is missing
+
+---
+
+## Files Reviewed
+
+- `/home/nicola/dev/backcast_evs/backend/app/services/impact_analysis_service.py` (lines 967-1352)
+- `/home/nicola/dev/backcast_evs/backend/app/models/domain/progress_entry.py`
+- `/home/nicola/dev/backcast_evs/backend/app/db/session.py`
+
+## Test Scripts Created
+
+- `/home/nicola/dev/backcast_evs/backend/debug_ev_issue.py`
+- `/home/nicola/dev/backcast_evs/backend/find_progress_entries.py`

--- a/backend/app/api/routes/change_orders.py
+++ b/backend/app/api/routes/change_orders.py
@@ -535,6 +535,10 @@ async def get_change_order_impact(
         pattern="^(merged|isolated)$",
         description="Comparison mode: merged (main+change) or isolated (change only)",
     ),
+    as_of: datetime | None = Query(
+        None,
+        description="Time travel: get impact analysis as of this timestamp (ISO 8601)",
+    ),
     service: ImpactAnalysisService = Depends(get_impact_analysis_service),
 ) -> ImpactAnalysisResponse:
     """Get impact analysis for a change order by comparing branches.
@@ -561,7 +565,7 @@ async def get_change_order_impact(
 
     try:
         impact_analysis = await service.analyze_impact(
-            change_order_id, branch_name, branch_mode=branch_mode
+            change_order_id, branch_name, branch_mode=branch_mode, as_of=as_of
         )
         return impact_analysis
     except ValueError as e:

--- a/backend/app/services/impact_analysis_service.py
+++ b/backend/app/services/impact_analysis_service.py
@@ -17,18 +17,21 @@ Per Phase 5 Plan:
 
 import asyncio
 import logging
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
+from sqlalchemy import cast as sql_cast
+from sqlalchemy.dialects.postgresql import TIMESTAMP
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.versioning.enums import BranchMode
 from app.models.domain.change_order import ChangeOrder
 from app.models.domain.cost_element import CostElement
 from app.models.domain.cost_registration import CostRegistration
+from app.models.domain.project import Project
 from app.models.domain.schedule_baseline import ScheduleBaseline
 from app.models.domain.wbe import WBE
 from app.models.schemas.evm import EntityType
@@ -77,6 +80,7 @@ class ImpactAnalysisService:
         branch_mode: BranchMode = BranchMode.MERGE,
         timeout_seconds: int = 300,
         include_evm_metrics: bool = True,
+        as_of: datetime | None = None,
     ) -> ImpactAnalysisResponse:
         """Analyze impact of a change order by comparing branches.
 
@@ -86,6 +90,12 @@ class ImpactAnalysisService:
         Branch Mode:
         - MERGE mode: Shows merged result (main + change delta) - most intuitive for users
         - STRICT mode: Shows isolated comparison (delta only) - for detailed analysis
+
+        Time Machine (as_of):
+        - When as_of is provided, filters all temporal data to include only entities
+          with valid_time starting before or at the as_of timestamp
+        - When as_of is None, returns current state (no temporal filtering)
+        - Edge case: as_of after current date behaves same as as_of=None (all current data)
 
         CostRegistration Note: CostRegistrations are NOT branchable (global facts).
         When joining CostRegistration → CostElement, we must filter by branch to
@@ -99,6 +109,7 @@ class ImpactAnalysisService:
             branch_mode: MERGE (default) shows merged result, STRICT shows isolated comparison
             timeout_seconds: Timeout in seconds (default: 300 = 5 minutes)
             include_evm_metrics: Whether to include expensive EVM metrics (CPI, SPI, etc.)
+            as_of: Time travel timestamp (None = current, past = historical point)
 
         Returns:
             ImpactAnalysisResponse with complete comparison data
@@ -133,7 +144,7 @@ class ImpactAnalysisService:
             # Create analysis task with timeout
             analysis_task = asyncio.create_task(
                 self._perform_analysis(
-                    change_order_id, branch_name, branch_mode, include_evm_metrics
+                    change_order_id, branch_name, branch_mode, include_evm_metrics, as_of
                 )
             )
 
@@ -174,6 +185,7 @@ class ImpactAnalysisService:
         branch_name: str,
         branch_mode: BranchMode,
         include_evm_metrics: bool = True,
+        as_of: datetime | None = None,
     ) -> ImpactAnalysisResponse:
         """Perform the actual impact analysis.
 
@@ -185,6 +197,7 @@ class ImpactAnalysisService:
             branch_name: Name of the change branch (e.g., "BR-CO-2026-001")
             branch_mode: MERGE mode calculates merged values, STRICT mode calculates isolated values
             include_evm_metrics: Whether to include expensive EVM metrics
+            as_of: Time travel timestamp (None = current, past = historical point)
 
         Returns:
             ImpactAnalysisResponse with complete comparison data
@@ -362,16 +375,8 @@ class ImpactAnalysisService:
         margin_delta = change_gross_margin - main_gross_margin
         waterfall = self._build_waterfall(main_gross_margin, margin_delta)
 
-        # Generate time-series data
-        time_series_points = await self._generate_time_series(project_id, branch_name)
-
-        # Format time-series data
-        time_series = [
-            TimeSeriesData(
-                metric_name="budget",
-                data_points=time_series_points,
-            )
-        ]
+        # Generate time-series data (returns 4 metrics: budget, pv, ev, ac)
+        time_series = await self._generate_time_series(project_id, branch_name, as_of)
 
         return ImpactAnalysisResponse(
             change_order_id=change_order_id,
@@ -642,7 +647,7 @@ class ImpactAnalysisService:
         wbe_cost_deltas: dict[UUID, Decimal] = {}
         ce_cost_deltas: dict[UUID, Decimal] = {}
 
-        for cr_change in cr_changes:
+        for _cr_change in cr_changes:
             # We need to find the registration to get its WBE/CE links
             # Searching for the change in our maps
             # (In a real system, we'd do this more efficiently during collation)
@@ -660,7 +665,7 @@ class ImpactAnalysisService:
         for cr_id in all_cr_ids:
             main_cr = main_cr_map.get(cr_id)
             merged_cr = merged_cr_map.get(cr_id)
-            
+
             delta = Decimal("0")
             ref_cr = None
 
@@ -680,7 +685,7 @@ class ImpactAnalysisService:
                 # Link to CostElement
                 ce_id = ref_cr.cost_element_id
                 ce_cost_deltas[ce_id] = ce_cost_deltas.get(ce_id, Decimal("0")) + delta
-                
+
                 # We need to find the WBE for this CE to aggregate up
                 # Optimization: we have merged_cost_elements list
                 pass
@@ -743,7 +748,7 @@ class ImpactAnalysisService:
                 assert (
                     change_wbe is not None
                 )  # Logically: root_id in union but not in main
-                
+
                 # For added entities, we show the full value as the delta
                 changes.append(
                     EntityChange(
@@ -823,7 +828,7 @@ class ImpactAnalysisService:
                 assert (
                     change_ce is not None
                 )  # Logically: root_id in union but not in main
-                
+
                 # For added entities, show full value as delta
                 changes.append(
                     EntityChange(
@@ -972,49 +977,574 @@ class ImpactAnalysisService:
         ]
 
     async def _generate_time_series(
-        self, project_id: UUID, branch_name: str
-    ) -> list[TimeSeriesPoint]:
-        """Generate weekly time-series data.
+        self, project_id: UUID, branch_name: str, as_of: datetime | None = None
+    ) -> list[TimeSeriesData]:
+        """Generate 4 time-series datasets for EVM S-curve visualization.
+
+        Context: Generates weekly cumulative values for Budget, Planned Value (PV),
+        Earned Value (EV), and Actual Cost (AC) across the project duration.
+        Used by the S-Curve Comparison tab in impact analysis to show full EVM
+        visibility with MERGE mode comparison between main and change branch.
+
+        Time Machine (as_of):
+        - When as_of is provided, filters all temporal data (ProgressEntry, CostRegistration,
+          CostElement, ScheduleBaseline, WBE) to include only entities with valid_time
+          starting before or at the as_of timestamp
+        - When as_of is None, returns current state (no temporal filtering)
+        - Edge case: as_of after current date behaves same as as_of=None (all current data)
+
+        Metrics:
+        - budget: Cumulative budget allocation (same as PV)
+        - pv: Planned Value from schedule baselines (BAC × scheduled %)
+        - ev: Earned Value from progress entries (BAC × actual %)
+        - ac: Actual Cost from cost registrations (cumulative spend)
+
+        Args:
+            project_id: UUID of the project
+            branch_name: Name of the change branch (e.g., "BR-CO-2026-001")
+            as_of: Time travel timestamp (None = current, past = historical point)
+
+        Returns:
+            List of 4 TimeSeriesData objects with metric_names:
+            - "budget": Cumulative budget allocation
+            - "pv": Planned Value (scheduled work)
+            - "ev": Earned Value (completed work)
+            - "ac": Actual Cost (incurred costs)
+
+            Returns empty list if no schedule baselines found.
+        """
+        from app.models.domain.progress_entry import ProgressEntry
+        from app.services.progression import get_progression_strategy
+
+        # ========================================================================
+        # STEP 1: Get project date range from schedule baselines
+        # ========================================================================
+        # Query all schedule baselines for cost elements in this project (both branches)
+        # CRITICAL: We must join WBE with branch matching CostElement.branch to ensure
+        # we get the correct budget_allocation for each branch's WBE version
+
+        # Apply temporal filtering if as_of is specified
+        if as_of is not None:
+            as_of_tstz = sql_cast(as_of, TIMESTAMP(timezone=True))
+            schedule_stmt = (
+                select(ScheduleBaseline, CostElement, WBE)
+                .join(
+                    CostElement,
+                    ScheduleBaseline.schedule_baseline_id == CostElement.schedule_baseline_id,
+                )
+                .join(
+                    WBE,
+                    and_(
+                        CostElement.wbe_id == WBE.wbe_id,
+                        WBE.branch == CostElement.branch,
+                    ),
+                )
+                .where(
+                    WBE.project_id == project_id,
+                    cast(Any, ScheduleBaseline).deleted_at.is_(None),
+                    # Time machine: Only include schedules/WBEs/CostElements valid at as_of
+                    ScheduleBaseline.valid_time.op("@>")(as_of_tstz),
+                    func.lower(ScheduleBaseline.valid_time) <= as_of_tstz,
+                    WBE.valid_time.op("@>")(as_of_tstz),
+                    func.lower(WBE.valid_time) <= as_of_tstz,
+                    CostElement.valid_time.op("@>")(as_of_tstz),
+                    func.lower(CostElement.valid_time) <= as_of_tstz,
+                )
+            )
+        else:
+            # No time filtering - get current schedules
+            schedule_stmt = (
+                select(ScheduleBaseline, CostElement, WBE)
+                .join(
+                    CostElement,
+                    ScheduleBaseline.schedule_baseline_id == CostElement.schedule_baseline_id,
+                )
+                .join(
+                    WBE,
+                    and_(
+                        CostElement.wbe_id == WBE.wbe_id,
+                        WBE.branch == CostElement.branch,
+                    ),
+                )
+                .where(
+                    WBE.project_id == project_id,
+                    ScheduleBaseline.deleted_at.is_(None),
+                    func.upper(ScheduleBaseline.valid_time).is_(None),
+                    WBE.deleted_at.is_(None),
+                    func.upper(WBE.valid_time).is_(None),
+                    CostElement.deleted_at.is_(None),
+                    func.upper(CostElement.valid_time).is_(None),
+                )
+            )
+
+        schedule_result = await self._db.execute(schedule_stmt)
+        schedules = schedule_result.all()
+
+        if not schedules:
+            # Fallback: If no schedules exist, use simple WBE-based budget calculation
+            # This handles projects that haven't set up schedule baselines yet
+            return await self._generate_simple_budget_series(project_id, branch_name, as_of)
+
+        # Separate by CostElement branch (not ScheduleBaseline.branch)
+        # ScheduleBaselines are shared across branches (they're in main), but CostElements
+        # determine which branch the schedule belongs to for comparison purposes
+        main_schedules = [s for s in schedules if s[1].branch == "main"]
+        change_schedules = [s for s in schedules if s[1].branch == branch_name]
+
+        if not main_schedules:
+            # Fallback: If no main schedules exist, use simple WBE-based budget calculation
+            return await self._generate_simple_budget_series(project_id, branch_name, as_of)
+
+        # ========================================================================
+        # STEP 1b: Determine date range for S-curve
+        # ========================================================================
+        # Prefer project-level dates over schedule baseline dates
+
+        # First, filter valid schedules (needed later in the code)
+        valid_main_schedules = [
+            s for s in main_schedules if s[0].start_date is not None and s[0].end_date is not None
+        ]
+
+        # Fetch the project's start_date and end_date from the main branch
+        project_result = await self._db.execute(
+            select(Project)
+            .where(
+                Project.project_id == project_id,
+                Project.branch == "main",
+                Project.deleted_at.is_(None),
+            )
+        )
+        project = project_result.scalar_one_or_none()
+
+        # Use project dates if available, otherwise fall back to schedule baseline dates
+        if project and project.start_date and project.end_date:
+            min_start = project.start_date
+            max_end = project.end_date
+        else:
+            # Fallback to schedule baseline dates
+            if not valid_main_schedules:
+                return []
+
+            min_start = min(s[0].start_date for s in valid_main_schedules)
+            max_end = max(s[0].end_date for s in valid_main_schedules)
+
+        # ========================================================================
+        # STEP 2: Batch fetch all required data for EVM calculations
+        # ========================================================================
+        # Get all cost element IDs for this project (both branches)
+        if as_of is not None:
+            as_of_tstz = sql_cast(as_of, TIMESTAMP(timezone=True))
+            all_cost_elements_stmt = (
+                select(CostElement)
+                .join(WBE, CostElement.wbe_id == WBE.wbe_id)
+                .where(
+                    WBE.project_id == project_id,
+                    CostElement.branch.in_(["main", branch_name]),
+                    CostElement.deleted_at.is_(None),
+                    # Time machine: Only include cost elements valid at as_of
+                    CostElement.valid_time.op("@>")(as_of_tstz),
+                    func.lower(CostElement.valid_time) <= as_of_tstz,
+                )
+            )
+        else:
+            # No time filtering - get current cost elements
+            all_cost_elements_stmt = (
+                select(CostElement)
+                .join(WBE, CostElement.wbe_id == WBE.wbe_id)
+                .where(
+                    WBE.project_id == project_id,
+                    CostElement.branch.in_(["main", branch_name]),
+                    func.upper(CostElement.valid_time).is_(None),
+                    CostElement.deleted_at.is_(None),
+                )
+            )
+        ce_result = await self._db.execute(all_cost_elements_stmt)
+        all_cost_elements = ce_result.scalars().all()
+
+        # Build cost element lookup by (cost_element_id, branch)
+        ce_lookup: dict[tuple[UUID, str], CostElement] = {}
+        for ce in all_cost_elements:
+            ce_lookup[(ce.cost_element_id, ce.branch)] = ce
+
+        # ========================================================================
+        # STEP 3: Batch fetch ProgressEntry data for EV calculation
+        # ========================================================================
+        # ProgressEntry is NOT branchable - need to filter by CostElement.branch
+        # We need to join with CostElement to know which branch the progress applies to
+        if as_of is not None:
+            as_of_tstz = sql_cast(as_of, TIMESTAMP(timezone=True))
+            progress_stmt = (
+                select(ProgressEntry, CostElement)
+                .join(CostElement, ProgressEntry.cost_element_id == CostElement.cost_element_id)
+                .join(WBE, CostElement.wbe_id == WBE.wbe_id)
+                .where(
+                    WBE.project_id == project_id,
+                    CostElement.branch.in_(["main", branch_name]),
+                    ProgressEntry.deleted_at.is_(None),
+                    # Time machine: Only include progress entries valid at as_of
+                    ProgressEntry.valid_time.op("@>")(as_of_tstz),
+                    func.lower(ProgressEntry.valid_time) <= as_of_tstz,
+                )
+            ).order_by(
+                CostElement.branch,
+                CostElement.cost_element_id,
+                func.lower(ProgressEntry.valid_time).desc()
+            )
+        else:
+            # No time filtering - get current progress entries
+            progress_stmt = (
+                select(ProgressEntry, CostElement)
+                .join(CostElement, ProgressEntry.cost_element_id == CostElement.cost_element_id)
+                .join(WBE, CostElement.wbe_id == WBE.wbe_id)
+                .where(
+                    WBE.project_id == project_id,
+                    CostElement.branch.in_(["main", branch_name]),
+                    ProgressEntry.deleted_at.is_(None),
+                    func.upper(ProgressEntry.valid_time).is_(None),
+                )
+            ).order_by(
+                CostElement.branch,
+                CostElement.cost_element_id,
+                func.lower(ProgressEntry.valid_time).desc()
+            )
+
+        progress_result = await self._db.execute(progress_stmt)
+        progress_rows = progress_result.all()
+
+        # Build progress lookup: (cost_element_id, branch) -> latest ProgressEntry
+        progress_lookup: dict[tuple[UUID, str], ProgressEntry] = {}
+        for pe, ce in progress_rows:
+            key = (ce.cost_element_id, ce.branch)
+            # Only keep the first (latest) entry for each key
+            if key not in progress_lookup:
+                progress_lookup[key] = pe
+
+        # ========================================================================
+        # STEP 4: Batch fetch CostRegistration data for AC calculation
+        # ========================================================================
+        # CostRegistration is NOT branchable - need to filter by CostElement.branch
+        # We fetch all registrations and will filter by CostElement.branch when aggregating
+        if as_of is not None:
+            as_of_tstz = sql_cast(as_of, TIMESTAMP(timezone=True))
+            cost_reg_stmt = (
+                select(CostRegistration, CostElement)
+                .join(CostElement, CostRegistration.cost_element_id == CostElement.cost_element_id)
+                .join(WBE, CostElement.wbe_id == WBE.wbe_id)
+                .where(
+                    WBE.project_id == project_id,
+                    CostElement.branch.in_(["main", branch_name]),
+                    CostRegistration.deleted_at.is_(None),
+                    # Time machine: Only include cost registrations valid at as_of
+                    CostRegistration.valid_time.op("@>")(as_of_tstz),
+                    func.lower(CostRegistration.valid_time) <= as_of_tstz,
+                )
+            ).order_by(CostRegistration.registration_date)
+        else:
+            # No time filtering - get current cost registrations
+            cost_reg_stmt = (
+                select(CostRegistration, CostElement)
+                .join(CostElement, CostRegistration.cost_element_id == CostElement.cost_element_id)
+                .join(WBE, CostElement.wbe_id == WBE.wbe_id)
+                .where(
+                    WBE.project_id == project_id,
+                    CostElement.branch.in_(["main", branch_name]),
+                    CostRegistration.deleted_at.is_(None),
+                    func.upper(CostRegistration.valid_time).is_(None),
+                )
+            ).order_by(CostRegistration.registration_date)
+
+        cost_reg_result = await self._db.execute(cost_reg_stmt)
+        cost_reg_rows = cost_reg_result.all()
+
+        # Build cost registration lookup: (cost_element_id, branch) -> list of registrations
+        from collections import defaultdict
+        cost_reg_lookup: dict[tuple[UUID, str], list[CostRegistration]] = defaultdict(list)
+        for cr, ce in cost_reg_rows:
+            cost_reg_lookup[(ce.cost_element_id, ce.branch)].append(cr)
+
+        # ========================================================================
+        # STEP 5: Generate weekly intervals
+        # ========================================================================
+        weekly_periods = []
+        current_week_start = min_start.replace(hour=0, minute=0, second=0, microsecond=0)
+
+        # Safety: Limit to 520 weeks (10 years) to prevent performance issues
+        max_weeks = 520
+        week_count = 0
+
+        while current_week_start <= max_end and week_count < max_weeks:
+            week_end = current_week_start + timedelta(days=6)
+            weekly_periods.append(
+                {"week_start": current_week_start, "week_end": min(week_end, max_end)}
+            )
+            current_week_start = week_end + timedelta(days=1)
+            week_count += 1
+
+        # ========================================================================
+        # STEP 6: Calculate metrics for each week
+        # ========================================================================
+        # We'll calculate all 4 metrics in a single pass through the schedules
+
+        # Initialize time series data for each metric
+        budget_series: list[TimeSeriesPoint] = []
+        pv_series: list[TimeSeriesPoint] = []
+        ev_series: list[TimeSeriesPoint] = []
+        ac_series: list[TimeSeriesPoint] = []
+
+        # Pre-group schedules by branch for efficient iteration
+        valid_change_schedules = [
+            s for s in change_schedules
+            if s[0].start_date is not None and s[0].end_date is not None
+        ]
+
+        # Build WBE ID sets for MERGE mode logic
+        main_wbe_ids = {s[2].wbe_id for s in valid_main_schedules}
+        change_wbe_ids = {s[2].wbe_id for s in valid_change_schedules}
+        only_in_main = main_wbe_ids - change_wbe_ids
+
+        for period in weekly_periods:
+            week_start = period["week_start"]
+            week_mid = period["week_start"] + timedelta(days=3)
+            week_start_date = week_start.date()
+
+            # Initialize accumulators for this week
+            main_budget = Decimal("0")
+            main_pv = Decimal("0")
+            main_ev = Decimal("0")
+            main_ac = Decimal("0")
+
+            change_budget = Decimal("0")
+            change_pv = Decimal("0")
+            change_ev = Decimal("0")
+            change_ac = Decimal("0")
+
+            # ------------------------------------------------------------
+            # Calculate main branch metrics
+            # ------------------------------------------------------------
+            for schedule, ce, wbe in valid_main_schedules:
+                budget = wbe.budget_allocation or Decimal("0")
+                if not (schedule.start_date and schedule.end_date):
+                    continue
+
+                try:
+                    # Budget/PV: Use progression strategy
+                    strategy = get_progression_strategy(schedule.progression_type)
+                    progress = strategy.calculate_progress(
+                        week_mid, schedule.start_date, schedule.end_date
+                    )
+                    budget_pv = Decimal(str(progress)) * budget
+
+                    main_budget += budget_pv
+                    main_pv += budget_pv
+
+                    # EV: Use progress entries
+                    pe = progress_lookup.get((ce.cost_element_id, "main"))
+                    if pe:
+                        ev = budget * pe.progress_percentage / Decimal("100")
+                        main_ev += ev
+                    # If no progress entry, EV = 0
+
+                    # AC: Use cost registrations (cumulative up to week_mid)
+                    registrations = cost_reg_lookup.get((ce.cost_element_id, "main"), [])
+                    for cr in registrations:
+                        if cr.registration_date and cr.registration_date <= week_mid:
+                            main_ac += cr.amount
+
+                except ValueError:
+                    # Skip invalid date ranges
+                    pass
+
+            # ------------------------------------------------------------
+            # Calculate change branch metrics
+            # ------------------------------------------------------------
+            for schedule, ce, wbe in valid_change_schedules:
+                budget = wbe.budget_allocation or Decimal("0")
+                if not (schedule.start_date and schedule.end_date):
+                    continue
+
+                try:
+                    # Budget/PV: Use progression strategy
+                    strategy = get_progression_strategy(schedule.progression_type)
+                    progress = strategy.calculate_progress(
+                        week_mid, schedule.start_date, schedule.end_date
+                    )
+                    budget_pv = Decimal(str(progress)) * budget
+
+                    change_budget += budget_pv
+                    change_pv += budget_pv
+
+                    # EV: Use progress entries
+                    pe = progress_lookup.get((ce.cost_element_id, branch_name))
+                    if pe:
+                        ev = budget * pe.progress_percentage / Decimal("100")
+                        change_ev += ev
+
+                    # AC: Use cost registrations
+                    registrations = cost_reg_lookup.get((ce.cost_element_id, branch_name), [])
+                    for cr in registrations:
+                        if cr.registration_date and cr.registration_date <= week_mid:
+                            change_ac += cr.amount
+
+                except ValueError:
+                    pass
+
+            # ------------------------------------------------------------
+            # MERGE mode: Add unchanged WBEs from main to change
+            # ------------------------------------------------------------
+            for schedule, ce, wbe in valid_main_schedules:
+                if wbe.wbe_id in only_in_main:
+                    budget = wbe.budget_allocation or Decimal("0")
+                    if not (schedule.start_date and schedule.end_date):
+                        continue
+
+                    try:
+                        strategy = get_progression_strategy(schedule.progression_type)
+                        progress = strategy.calculate_progress(
+                            week_mid, schedule.start_date, schedule.end_date
+                        )
+                        budget_pv = Decimal(str(progress)) * budget
+
+                        change_budget += budget_pv
+                        change_pv += budget_pv
+
+                        # EV: Use progress entries from main
+                        pe = progress_lookup.get((ce.cost_element_id, "main"))
+                        if pe:
+                            ev = budget * pe.progress_percentage / Decimal("100")
+                            change_ev += ev
+
+                        # AC: Use cost registrations from main
+                        registrations = cost_reg_lookup.get((ce.cost_element_id, "main"), [])
+                        for cr in registrations:
+                            if cr.registration_date and cr.registration_date <= week_mid:
+                                change_ac += cr.amount
+
+                    except ValueError:
+                        pass
+
+            # ------------------------------------------------------------
+            # Create time series points for this week
+            # ------------------------------------------------------------
+            budget_series.append(
+                TimeSeriesPoint(
+                    week_start=week_start_date,
+                    main_value=main_budget,
+                    change_value=change_budget,
+                )
+            )
+            pv_series.append(
+                TimeSeriesPoint(
+                    week_start=week_start_date,
+                    main_value=main_pv,
+                    change_value=change_pv,
+                )
+            )
+            ev_series.append(
+                TimeSeriesPoint(
+                    week_start=week_start_date,
+                    main_value=main_ev,
+                    change_value=change_ev,
+                )
+            )
+            ac_series.append(
+                TimeSeriesPoint(
+                    week_start=week_start_date,
+                    main_value=main_ac,
+                    change_value=change_ac,
+                )
+            )
+
+        # ========================================================================
+        # STEP 7: Build and return the 4 time series
+        # ========================================================================
+        return [
+            TimeSeriesData(metric_name="budget", data_points=budget_series),
+            TimeSeriesData(metric_name="pv", data_points=pv_series),
+            TimeSeriesData(metric_name="ev", data_points=ev_series),
+            TimeSeriesData(metric_name="ac", data_points=ac_series),
+        ]
+
+    async def _generate_simple_budget_series(
+        self, project_id: UUID, branch_name: str, as_of: datetime | None = None
+    ) -> list[TimeSeriesData]:
+        """Generate simple budget-based time series when no schedules exist.
+
+        Fallback method for projects without schedule baselines.
+        Calculates budget totals from WBEs only.
 
         Args:
             project_id: UUID of the project
             branch_name: Name of the change branch
+            as_of: Time travel timestamp (None = current, past = historical point)
 
         Returns:
-            List of weekly TimeSeriesPoint objects
+            List with single TimeSeriesData for budget metric
         """
         # Get total budget from main branch
-        main_budget_stmt = select(func.sum(WBE.budget_allocation)).where(
-            WBE.project_id == project_id,
-            WBE.branch == "main",
-            func.upper(cast(Any, WBE).valid_time).is_(None),
-            cast(Any, WBE).deleted_at.is_(None),
-        )
+        if as_of is not None:
+            as_of_tstz = sql_cast(as_of, TIMESTAMP(timezone=True))
+            main_budget_stmt = (
+                select(func.sum(WBE.budget_allocation))
+                .where(
+                    WBE.project_id == project_id,
+                    WBE.branch == "main",
+                    WBE.deleted_at.is_(None),
+                    WBE.valid_time.op("@>")(as_of_tstz),
+                    func.lower(WBE.valid_time) <= as_of_tstz,
+                )
+            )
+        else:
+            main_budget_stmt = (
+                select(func.sum(WBE.budget_allocation))
+                .where(
+                    WBE.project_id == project_id,
+                    WBE.branch == "main",
+                    func.upper(cast(Any, WBE).valid_time).is_(None),
+                    cast(Any, WBE).deleted_at.is_(None),
+                )
+            )
         main_budget_result = await self._db.execute(main_budget_stmt)
         main_total = main_budget_result.scalar() or Decimal("0")
 
         # Get total budget from change branch
-        change_budget_stmt = select(func.sum(WBE.budget_allocation)).where(
-            WBE.project_id == project_id,
-            WBE.branch == branch_name,
-            func.upper(cast(Any, WBE).valid_time).is_(None),
-            cast(Any, WBE).deleted_at.is_(None),
-        )
+        if as_of is not None:
+            as_of_tstz = sql_cast(as_of, TIMESTAMP(timezone=True))
+            change_budget_stmt = (
+                select(func.sum(WBE.budget_allocation))
+                .where(
+                    WBE.project_id == project_id,
+                    WBE.branch == branch_name,
+                    WBE.deleted_at.is_(None),
+                    WBE.valid_time.op("@>")(as_of_tstz),
+                    func.lower(WBE.valid_time) <= as_of_tstz,
+                )
+            )
+        else:
+            change_budget_stmt = (
+                select(func.sum(WBE.budget_allocation))
+                .where(
+                    WBE.project_id == project_id,
+                    WBE.branch == branch_name,
+                    func.upper(cast(Any, WBE).valid_time).is_(None),
+                    cast(Any, WBE).deleted_at.is_(None),
+                )
+            )
         change_budget_result = await self._db.execute(change_budget_stmt)
         change_total = change_budget_result.scalar() or Decimal("0")
 
         # Return as a single time point (current week)
-        # Note: Full implementation would aggregate historical data by week
-        # For now, we return current budget totals as the latest time point
-        current_week_start = date.today().replace(
-            day=1
-        )  # First of current month as approximation
+        current_week_start = datetime.now(UTC).date()
+
+        budget_point = TimeSeriesPoint(
+            week_start=current_week_start,
+            main_value=main_total,
+            change_value=change_total,
+        )
 
         return [
-            TimeSeriesPoint(
-                week_start=current_week_start,
-                main_value=main_total,
-                change_value=change_total,
+            TimeSeriesData(
+                metric_name="budget",
+                data_points=[budget_point],
             )
         ]
 

--- a/backend/tests/integration/test_s_curve_bug_fix.py
+++ b/backend/tests/integration/test_s_curve_bug_fix.py
@@ -1,0 +1,194 @@
+"""Integration test for S-Curve time series generation bug fix.
+
+This test reproduces the issue where main and change branch S-curves
+are identical when they should be different due to cost element modifications.
+
+The root cause: The implementation needs to properly query budget_allocation
+from WBEs, not cost_element budget_amount.
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.domain.cost_element import CostElement
+from app.models.domain.cost_element_type import CostElementType
+from app.models.domain.department import Department
+from app.models.domain.schedule_baseline import ScheduleBaseline
+from app.models.domain.wbe import WBE
+from app.services.impact_analysis_service import ImpactAnalysisService
+
+
+@pytest.mark.asyncio
+async def test_s_curve_shows_differences_when_wbe_budget_changes(
+    db_session: AsyncSession,
+) -> None:
+    """Test that S-curve shows different values when WBE budget changes on change branch.
+
+    This is the BUG FIX TEST case:
+    - Main branch: WBE with $100,000 budget_allocation
+    - Change branch: Same WBE with $150,000 budget_allocation (50% increase)
+    - Expected: Change branch S-curve values should be 50% higher than main branch
+    - Bug: Both curves are identical (the issue reported by user)
+    """
+    # Arrange
+    service = ImpactAnalysisService(db_session)
+    project_id = uuid4()
+    wbe_id = uuid4()
+    dept_id = uuid4()
+    user_id = uuid4()  # For created_by field
+    branch_name = "BR-CO-2026-001"
+
+    # Create department
+    dept = Department(
+        department_id=dept_id,
+        code="ENG",
+        name="Engineering",
+        manager_id=user_id,
+    )
+    db_session.add(dept)
+
+    # Create cost element type (not branchable, no branch field)
+    cet = CostElementType(
+        cost_element_type_id=uuid4(),
+        department_id=dept_id,
+        code="LABOR",
+        name="Labor",
+        description="Labor costs",
+        created_by=user_id,
+    )
+    db_session.add(cet)
+
+    # Create main branch WBE with $100k budget
+    main_wbe = WBE(
+        wbe_id=wbe_id,
+        project_id=project_id,
+        code="1.1",
+        name="Assembly Station",
+        budget_allocation=Decimal("100000.00"),  # Main: $100k
+        revenue_allocation=Decimal("120000.00"),
+        branch="main",
+    )
+    db_session.add(main_wbe)
+
+    # Create change branch WBE with $150k budget (50% increase)
+    change_wbe = WBE(
+        wbe_id=wbe_id,
+        project_id=project_id,
+        code="1.1",
+        name="Assembly Station",
+        budget_allocation=Decimal("150000.00"),  # Change: $150k (50% higher)
+        revenue_allocation=Decimal("180000.00"),
+        branch=branch_name,
+    )
+    db_session.add(change_wbe)
+
+    # Create schedule baselines with same dates
+    schedule_start = datetime(2026, 1, 1, tzinfo=UTC)
+    schedule_end = datetime(2026, 12, 31, tzinfo=UTC)
+
+    # Main branch schedule baseline
+    main_cost_elem = CostElement(
+        cost_element_id=uuid4(),
+        wbe_id=wbe_id,
+        cost_element_type_id=cet.cost_element_type_id,
+        code="CE-001",
+        name="Labor Cost",
+        budget_amount=Decimal("100000.00"),
+        branch="main",
+        created_by=user_id,
+    )
+    db_session.add(main_cost_elem)
+
+    main_schedule = ScheduleBaseline(
+        schedule_baseline_id=uuid4(),
+        cost_element_id=main_cost_elem.cost_element_id,
+        name="Main Schedule",
+        start_date=schedule_start,
+        end_date=schedule_end,
+        progression_type="LINEAR",
+        branch="main",
+        created_by=user_id,
+    )
+    db_session.add(main_schedule)
+    main_cost_elem.schedule_baseline_id = main_schedule.schedule_baseline_id
+
+    # Change branch schedule baseline
+    change_cost_elem = CostElement(
+        cost_element_id=uuid4(),
+        wbe_id=wbe_id,
+        cost_element_type_id=cet.cost_element_type_id,
+        code="CE-001",
+        name="Labor Cost",
+        budget_amount=Decimal("150000.00"),  # Higher budget on change branch
+        branch=branch_name,
+        created_by=user_id,
+    )
+    db_session.add(change_cost_elem)
+
+    change_schedule = ScheduleBaseline(
+        schedule_baseline_id=uuid4(),
+        cost_element_id=change_cost_elem.cost_element_id,
+        name="Change Schedule",
+        start_date=schedule_start,
+        end_date=schedule_end,
+        progression_type="LINEAR",
+        branch=branch_name,
+        created_by=user_id,
+    )
+    db_session.add(change_schedule)
+    change_cost_elem.schedule_baseline_id = change_schedule.schedule_baseline_id
+
+    await db_session.commit()
+
+    # Act
+    result = await service._generate_time_series(project_id, branch_name)
+
+    # Assert
+    assert len(result) == 4, "Should return 4 time series (budget, pv, ev, ac)"
+
+    # Get budget time series
+    budget_series = next((ts for ts in result if ts.metric_name == "budget"), None)
+    assert budget_series is not None, "Should have budget time series"
+
+    data_points = budget_series.data_points
+    assert len(data_points) > 1, "Should generate multiple weekly data points"
+
+    # CRITICAL ASSERTION: The curves should be different!
+    # At any given week, change_value should be 1.5x main_value
+    differences_found = False
+    for i, point in enumerate(data_points):
+        main_val = point.main_value or Decimal("0")
+        change_val = point.change_value or Decimal("0")
+
+        # Skip first and last points where values might be zero
+        if 0 < i < len(data_points) - 1:
+            # Change should be 1.5x main (50% increase)
+            if main_val > 0:
+                ratio = change_val / main_val
+                # Allow small tolerance for floating point arithmetic
+                if abs(ratio - Decimal("1.5")) > Decimal("0.01"):
+                    # This is expected - they should be different
+                    differences_found = True
+                    print(f"Week {point.week_start}: main={main_val}, change={change_val}, ratio={ratio}")
+                    break
+
+    # Verify that curves are NOT identical
+    final_main = data_points[-1].main_value or Decimal("0")
+    final_change = data_points[-1].change_value or Decimal("0")
+
+    assert differences_found or (
+        abs(final_main - Decimal("100000.00")) < Decimal("1000.00")
+        and abs(final_change - Decimal("150000.00")) < Decimal("1000.00")
+    ), (
+        f"BUG: S-curves are identical! Main={final_main}, Change={final_change}. "
+        f"Expected change to be 1.5x main. "
+        f"This indicates the implementation is not correctly reading WBE.budget_allocation."
+    )
+
+    # Final verification
+    assert final_main == Decimal("100000.00"), f"Main final value should be $100k, got {final_main}"
+    assert final_change == Decimal("150000.00"), f"Change final value should be $150k, got {final_change}"

--- a/backend/tests/integration/test_s_curve_time_series.py
+++ b/backend/tests/integration/test_s_curve_time_series.py
@@ -1,0 +1,614 @@
+"""Integration tests for S-Curve time series generation in Impact Analysis.
+
+Tests the _generate_time_series() method with realistic database scenarios
+including edge cases for branch differences, progression types, and schedule variations.
+
+Updated to test 4 EVM metrics: budget, PV, EV, AC.
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.domain.cost_element import CostElement
+from app.models.domain.cost_element_type import CostElementType
+from app.models.domain.department import Department
+from app.models.domain.schedule_baseline import ScheduleBaseline
+from app.models.domain.wbe import WBE
+from app.services.impact_analysis_service import ImpactAnalysisService
+
+
+@pytest.mark.asyncio
+class TestSCurveTimeSeriesGeneration:
+    """Test S-curve time series generation with various edge cases.
+
+    Edge Case 1: Budget increase on change branch
+    - Main branch: WBE with $50k budget
+    - Change branch: Same WBE with $75k budget (50% increase)
+    - Expected: Change branch values should be 50% higher than main
+
+    Edge Case 2: New WBE added on change branch
+    - Main branch: 1 WBE with $100k budget
+    - Change branch: 2 WBEs (original + new $50k)
+    - Expected: Change branch cumulative should include both WBEs
+
+    Edge Case 3: Progression type change
+    - Main branch: LINEAR progression
+    - Change branch: GAUSSIAN progression (S-curve)
+    - Expected: Different curve shapes, same total budget
+
+    Edge Case 4: Schedule duration extension
+    - Main branch: 6-month schedule
+    - Change branch: 9-month schedule (extended)
+    - Expected: Flatter curve over longer period
+    """
+
+    async def test_s_curve_with_budget_increase(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test S-curve when change branch increases WBE budget.
+
+        Edge Case 1: Budget Increase
+        - Main: WBE-1 with $50,000 budget, LINEAR progression, 6 months
+        - Change: WBE-1 with $75,000 budget (50% increase), same schedule
+        - Expected: Change curve should be 50% higher at all points
+        """
+        # Arrange
+        service = ImpactAnalysisService(db_session)
+        project_id = uuid4()
+        wbe_id = uuid4()
+        dept_id = uuid4()
+        branch_name = "BR-test-001"
+
+        # Create department
+        dept = Department(
+            department_id=dept_id,
+            code="ENG",
+            name="Engineering",
+            manager_id=uuid4(),
+        )
+        db_session.add(dept)
+
+        # Create cost element type
+        cet_id = self._create_cost_element_type(db_session, dept_id)
+
+        # Create WBEs and cost elements
+        main_wbe = WBE(
+            wbe_id=wbe_id,
+            project_id=project_id,
+            code="1.1",
+            name="Assembly",
+            budget_allocation=Decimal("50000.00"),
+            revenue_allocation=Decimal("60000.00"),
+            branch="main",
+        )
+        db_session.add(main_wbe)
+
+        change_wbe = WBE(
+            wbe_id=wbe_id,
+            project_id=project_id,
+            code="1.1",
+            name="Assembly",
+            budget_allocation=Decimal("75000.00"),  # 50% increase
+            revenue_allocation=Decimal("90000.00"),
+            branch=branch_name,
+        )
+        db_session.add(change_wbe)
+
+        # Create schedule baselines with dates
+        schedule_start = datetime(2026, 1, 1, tzinfo=UTC)
+        schedule_end = datetime(2026, 6, 30, tzinfo=UTC)
+
+        self._create_schedule_baseline(
+            db_session, wbe_id, cet_id, "main", schedule_start, schedule_end, "LINEAR"
+        )
+        self._create_schedule_baseline(
+            db_session, wbe_id, cet_id, branch_name, schedule_start, schedule_end, "LINEAR"
+        )
+
+        await db_session.commit()
+
+        # Act
+        result = await service._generate_time_series(project_id, branch_name)
+
+        # Assert
+        assert len(result) == 4, "Should return 4 time series (budget, pv, ev, ac)"
+
+        # Get budget time series
+        budget_series = next((ts for ts in result if ts.metric_name == "budget"), None)
+        assert budget_series is not None, "Should have budget time series"
+
+        data_points = budget_series.data_points
+        assert len(data_points) > 1, "Should generate multiple weekly data points"
+
+        # Check that change branch values are consistently 50% higher
+        for point in data_points:
+            main_val = point.main_value or Decimal("0")
+            change_val = point.change_value or Decimal("0")
+
+            # Change should be 1.5x main (50% increase)
+            if main_val > 0:
+                ratio = change_val / main_val
+                assert (
+                    abs(ratio - Decimal("1.5")) < Decimal("0.01")
+                ), f"At {point.week_start}, change ({change_val}) should be ~1.5x main ({main_val}), got ratio {ratio}"
+
+        # Verify final cumulative values match total budgets
+        final_point = data_points[-1]
+        assert final_point.main_value == Decimal("50000.00")
+        assert final_point.change_value == Decimal("75000.00")
+
+    async def test_s_curve_with_new_wbe_added(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test S-curve when change branch adds a new WBE.
+
+        Edge Case 2: New WBE Added
+        - Main: 1 WBE with $100k budget, LINEAR, 6 months
+        - Change: 2 WBEs (original $100k + new $50k), same schedule
+        - Expected: Change cumulative = $100k (original) + $50k (new) = $150k
+        """
+        # Arrange
+        service = ImpactAnalysisService(db_session)
+        project_id = uuid4()
+        wbe_1_id = uuid4()
+        wbe_2_id = uuid4()  # New WBE only in change branch
+        cet_id = uuid4()
+        branch_name = "BR-test-002"
+
+        # Create cost element type
+        cet = CostElementType(
+            cost_element_type_id=cet_id,
+            code="LABOR",
+            name="Labor",
+            description="Labor costs",
+            branch="main",
+        )
+        db_session.add(cet)
+
+        # Create main branch WBE-1 with $100k budget
+        main_wbe_1 = WBE(
+            wbe_id=wbe_1_id,
+            project_id=project_id,
+            code="1.1",
+            name="Assembly Station",
+            budget_allocation=Decimal("100000.00"),
+            revenue_allocation=Decimal("120000.00"),
+            branch="main",
+        )
+        db_session.add(main_wbe_1)
+
+        # Create change branch WBE-1 (same as main)
+        change_wbe_1 = WBE(
+            wbe_id=wbe_1_id,
+            project_id=project_id,
+            code="1.1",
+            name="Assembly Station",
+            budget_allocation=Decimal("100000.00"),
+            revenue_allocation=Decimal("120000.00"),
+            branch=branch_name,
+        )
+        db_session.add(change_wbe_1)
+
+        # Create NEW WBE-2 only on change branch
+        change_wbe_2 = WBE(
+            wbe_id=wbe_2_id,
+            project_id=project_id,
+            code="1.2",
+            name="Test Station",  # New WBE
+            budget_allocation=Decimal("50000.00"),  # Additional $50k
+            revenue_allocation=Decimal("60000.00"),
+            branch=branch_name,
+        )
+        db_session.add(change_wbe_2)
+
+        # Create schedule baselines
+        schedule_start = datetime(2026, 1, 1, tzinfo=UTC)
+        schedule_end = datetime(2026, 6, 30, tzinfo=UTC)
+
+        self._create_schedule_baseline(
+            db_session, wbe_1_id, cet_id, "main", schedule_start, schedule_end, "LINEAR"
+        )
+        self._create_schedule_baseline(
+            db_session, wbe_1_id, cet_id, branch_name, schedule_start, schedule_end, "LINEAR"
+        )
+        self._create_schedule_baseline(
+            db_session, wbe_2_id, cet_id, branch_name, schedule_start, schedule_end, "LINEAR"
+        )
+
+        await db_session.commit()
+
+        # Act
+        result = await service._generate_time_series(project_id, branch_name)
+
+        # Assert
+        assert len(result) == 4, "Should return 4 time series (budget, pv, ev, ac)"
+
+        # Get budget time series
+        budget_series = next((ts for ts in result if ts.metric_name == "budget"), None)
+        assert budget_series is not None, "Should have budget time series"
+
+        data_points = budget_series.data_points
+        assert len(data_points) > 1, "Should generate multiple weekly data points"
+
+        # Verify final cumulative values
+        final_point = data_points[-1]
+        assert final_point.main_value == Decimal("100000.00"), "Main branch should have $100k total"
+        assert (
+            final_point.change_value == Decimal("150000.00")
+        ), "Change branch should have $150k total ($100k + $50k new WBE)"
+
+        # Verify that change branch is consistently $50k higher throughout
+        mid_point = data_points[len(data_points) // 2]
+        main_mid = mid_point.main_value or Decimal("0")
+        change_mid = mid_point.change_value or Decimal("0")
+        delta = change_mid - main_mid
+
+        # Delta should be approximately $50k (the new WBE's contribution)
+        # We allow some tolerance due to weekly aggregation
+        assert abs(delta - Decimal("50000.00")) < Decimal("5000.00"), (
+            f"Delta should be ~$50k, got {delta} "
+            f"(main={main_mid}, change={change_mid})"
+        )
+
+    async def test_s_curve_with_progression_type_change(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test S-curve when progression type changes between branches.
+
+        Edge Case 3: Progression Type Change
+        - Main: LINEAR progression (straight line)
+        - Change: GAUSSIAN progression (S-curve)
+        - Expected: Different curve shapes, same total budget
+        - Gaussian should be lower at start, higher in middle, similar at end
+        """
+        # Arrange
+        service = ImpactAnalysisService(db_session)
+        project_id = uuid4()
+        wbe_id = uuid4()
+        cet_id = uuid4()
+        branch_name = "BR-test-003"
+
+        # Create cost element type
+        cet = CostElementType(
+            cost_element_type_id=cet_id,
+            code="LABOR",
+            name="Labor",
+            description="Labor costs",
+            branch="main",
+        )
+        db_session.add(cet)
+
+        # Create WBEs with same budget
+        main_wbe = WBE(
+            wbe_id=wbe_id,
+            project_id=project_id,
+            code="1.1",
+            name="Assembly",
+            budget_allocation=Decimal("100000.00"),
+            revenue_allocation=Decimal("120000.00"),
+            branch="main",
+        )
+        db_session.add(main_wbe)
+
+        change_wbe = WBE(
+            wbe_id=wbe_id,
+            project_id=project_id,
+            code="1.1",
+            name="Assembly",
+            budget_allocation=Decimal("100000.00"),
+            revenue_allocation=Decimal("120000.00"),
+            branch=branch_name,
+        )
+        db_session.add(change_wbe)
+
+        # Create schedule baselines with DIFFERENT progression types
+        schedule_start = datetime(2026, 1, 1, tzinfo=UTC)
+        schedule_end = datetime(2026, 12, 31, tzinfo=UTC)  # Full year for better S-curve visibility
+
+        self._create_schedule_baseline(
+            db_session, wbe_id, cet_id, "main", schedule_start, schedule_end, "LINEAR"
+        )
+        self._create_schedule_baseline(
+            db_session, wbe_id, cet_id, branch_name, schedule_start, schedule_end, "GAUSSIAN"
+        )
+
+        await db_session.commit()
+
+        # Act
+        result = await service._generate_time_series(project_id, branch_name)
+
+        # Assert
+        assert len(result) == 4, "Should return 4 time series (budget, pv, ev, ac)"
+
+        # Get budget time series
+        budget_series = next((ts for ts in result if ts.metric_name == "budget"), None)
+        assert budget_series is not None, "Should have budget time series"
+
+        data_points = budget_series.data_points
+        assert len(data_points) > 10, "Should generate many weekly data points for a year-long project"
+
+        # Verify final values are the same (same total budget)
+        final_point = data_points[-1]
+        assert final_point.main_value == Decimal("100000.00")
+        assert final_point.change_value == Decimal("100000.00")
+
+        # Verify curve shapes are different
+        # At the start, LINEAR should be higher than GAUSSIAN (S-curve starts slow)
+        first_point = data_points[0]
+        main_first = first_point.main_value or Decimal("0")
+        change_first = first_point.change_value or Decimal("0")
+
+        # Linear starts immediately, Gaussian starts slower
+        assert main_first > change_first, (
+            f"LINEAR should start higher than GAUSSIAN at start: "
+            f"main={main_first}, change={change_first}"
+        )
+
+        # In the middle, GAUSSIAN should be higher than LINEAR (S-curve peaks)
+        mid_point = data_points[len(data_points) // 2]
+        main_mid = mid_point.main_value or Decimal("0")
+        change_mid = mid_point.change_value or Decimal("0")
+
+        # At midpoint, Gaussian S-curve should be ahead of Linear
+        assert change_mid > main_mid, (
+            f"GAUSSIAN should be higher than LINEAR at midpoint: "
+            f"main={main_mid}, change={change_mid}"
+        )
+
+    async def test_s_curve_with_schedule_extension(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test S-curve when schedule duration is extended on change branch.
+
+        Edge Case 4: Schedule Duration Extension
+        - Main: 6-month schedule, $100k budget
+        - Change: 9-month schedule (50% longer), same $100k budget
+        - Expected: Flatter curve over longer period (slower accumulation)
+        """
+        # Arrange
+        service = ImpactAnalysisService(db_session)
+        project_id = uuid4()
+        wbe_id = uuid4()
+        cet_id = uuid4()
+        branch_name = "BR-test-004"
+
+        # Create cost element type
+        cet = CostElementType(
+            cost_element_type_id=cet_id,
+            code="LABOR",
+            name="Labor",
+            description="Labor costs",
+            branch="main",
+        )
+        db_session.add(cet)
+
+        # Create WBEs with same budget
+        main_wbe = WBE(
+            wbe_id=wbe_id,
+            project_id=project_id,
+            code="1.1",
+            name="Assembly",
+            budget_allocation=Decimal("100000.00"),
+            revenue_allocation=Decimal("120000.00"),
+            branch="main",
+        )
+        db_session.add(main_wbe)
+
+        change_wbe = WBE(
+            wbe_id=wbe_id,
+            project_id=project_id,
+            code="1.1",
+            name="Assembly",
+            budget_allocation=Decimal("100000.00"),
+            revenue_allocation=Decimal("120000.00"),
+            branch=branch_name,
+        )
+        db_session.add(change_wbe)
+
+        # Create schedule baselines with DIFFERENT durations
+        main_start = datetime(2026, 1, 1, tzinfo=UTC)
+        main_end = datetime(2026, 6, 30, tzinfo=UTC)  # 6 months
+
+        change_start = datetime(2026, 1, 1, tzinfo=UTC)
+        change_end = datetime(2026, 9, 30, tzinfo=UTC)  # 9 months (50% longer)
+
+        self._create_schedule_baseline(
+            db_session, wbe_id, cet_id, "main", main_start, main_end, "LINEAR"
+        )
+        self._create_schedule_baseline(
+            db_session, wbe_id, cet_id, branch_name, change_start, change_end, "LINEAR"
+        )
+
+        await db_session.commit()
+
+        # Act
+        result = await service._generate_time_series(project_id, branch_name)
+
+        # Assert
+        assert len(result) == 4, "Should return 4 time series (budget, pv, ev, ac)"
+
+        # Get budget time series
+        budget_series = next((ts for ts in result if ts.metric_name == "budget"), None)
+        assert budget_series is not None, "Should have budget time series"
+
+        data_points = budget_series.data_points
+        assert len(data_points) > 1, "Should generate multiple weekly data points"
+
+        # Find the point at 3 months (end of main's 50% mark)
+        three_months_point = None
+        for point in data_points:
+            if point.week_start.month == 4 and point.week_start.day <= 7:
+                three_months_point = point
+                break
+
+        assert three_months_point is not None, "Should find a point around 3 months"
+
+        # At 3 months:
+        # - Main (6-month): Should have ~50% of budget ($50k)
+        # - Change (9-month): Should have ~33% of budget ($33k)
+        main_at_3m = three_months_point.main_value or Decimal("0")
+        change_at_3m = three_months_point.change_value or Decimal("0")
+
+        # Main should be ahead because it's shorter duration
+        assert main_at_3m > change_at_3m, (
+            f"Main (6-month) should be ahead of Change (9-month) at 3 months: "
+            f"main={main_at_3m}, change={change_at_3m}"
+        )
+
+        # Verify main has approximately 50% at midpoint
+        assert (
+            abs(main_at_3m - Decimal("50000.00")) < Decimal("10000.00")
+        ), f"Main should have ~$50k at 3 months, got {main_at_3m}"
+
+        # Verify change has approximately 33% at 3 months
+        assert (
+            abs(change_at_3m - Decimal("33333.00")) < Decimal("10000.00")
+        ), f"Change should have ~$33k at 3 months, got {change_at_3m}"
+
+    async def test_s_curve_empty_project(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test S-curve generation when project has no WBEs or schedules.
+
+        Edge Case 5: Empty Project
+        - Project exists but has no WBEs or schedule baselines
+        - Expected: Return empty list (graceful degradation)
+        """
+        # Arrange
+        service = ImpactAnalysisService(db_session)
+        project_id = uuid4()
+        branch_name = "BR-test-empty"
+
+        # Don't create any WBEs or schedules
+
+        # Act
+        result = await service._generate_time_series(project_id, branch_name)
+
+        # Assert
+        assert result == [], "Should return empty list for project with no schedules"
+
+    async def test_s_curve_no_schedule_baselines(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Test S-curve generation when WBEs exist but have no schedule baselines.
+
+        Edge Case 6: WBEs Without Schedule Baselines
+        - Project has WBEs but no schedule baselines
+        - Expected: Return empty list (can't generate time series without schedules)
+        """
+        # Arrange
+        service = ImpactAnalysisService(db_session)
+        project_id = uuid4()
+        wbe_id = uuid4()
+        cet_id = uuid4()
+        branch_name = "BR-test-no-schedule"
+
+        # Create cost element type
+        cet = CostElementType(
+            cost_element_type_id=cet_id,
+            code="LABOR",
+            name="Labor",
+            description="Labor costs",
+            branch="main",
+        )
+        db_session.add(cet)
+
+        # Create WBE without schedule baseline
+        main_wbe = WBE(
+            wbe_id=wbe_id,
+            project_id=project_id,
+            code="1.1",
+            name="Assembly Station",
+            budget_allocation=Decimal("100000.00"),
+            revenue_allocation=Decimal("120000.00"),
+            branch="main",
+        )
+        db_session.add(main_wbe)
+
+        await db_session.commit()
+
+        # Act
+        result = await service._generate_time_series(project_id, branch_name)
+
+        # Assert
+        assert result == [], "Should return empty list when no schedule baselines exist"
+
+    def _create_schedule_baseline(
+        self,
+        db_session: AsyncSession,
+        wbe_id: UUID,
+        cost_element_type_id: UUID,
+        branch: str,
+        start_date: datetime,
+        end_date: datetime,
+        progression_type: str,
+    ) -> ScheduleBaseline:
+        """Helper method to create a complete schedule baseline with cost element.
+
+        Args:
+            db_session: Database session
+            wbe_id: WBE root ID
+            cost_element_type_id: Cost element type ID
+            branch: Branch name
+            start_date: Schedule start date
+            end_date: Schedule end date
+            progression_type: Progression type (LINEAR, GAUSSIAN, LOGARITHMIC)
+
+        Returns:
+            Created ScheduleBaseline instance
+        """
+        # Create cost element
+        cost_elem = CostElement(
+            cost_element_id=uuid4(),
+            wbe_id=wbe_id,
+            cost_element_type_id=cost_element_type_id,
+            code="CE-001",
+            name="Cost Element",
+            budget_amount=Decimal("100000.00"),
+            branch=branch,
+        )
+        db_session.add(cost_elem)
+
+        # Create schedule baseline
+        schedule = ScheduleBaseline(
+            schedule_baseline_id=uuid4(),
+            cost_element_id=cost_elem.cost_element_id,
+            name=f"Schedule {branch}",
+            start_date=start_date,
+            end_date=end_date,
+            progression_type=progression_type,
+            branch=branch,
+        )
+        db_session.add(schedule)
+
+        # Link schedule to cost element (inverted FK)
+        cost_elem.schedule_baseline_id = schedule.schedule_baseline_id
+
+        return schedule
+
+    def _create_cost_element_type(
+        self, db_session: AsyncSession, department_id: UUID
+    ) -> UUID:
+        """Helper method to create a cost element type.
+
+        Args:
+            db_session: Database session
+            department_id: Department ID for the cost element type
+
+        Returns:
+            Created cost element type ID
+        """
+        cet_id = uuid4()
+        cet = CostElementType(
+            cost_element_type_id=cet_id,
+            department_id=department_id,
+            code="LABOR",
+            name="Labor",
+            description="Labor costs",
+        )
+        db_session.add(cet)
+        return cet_id

--- a/frontend/src/features/change-orders/components/ImpactAnalysisDashboard.tsx
+++ b/frontend/src/features/change-orders/components/ImpactAnalysisDashboard.tsx
@@ -4,7 +4,7 @@ import { useImpactAnalysis } from "../api/useImpactAnalysis";
 import { useChangeOrder } from "../api/useChangeOrders";
 import { KPICards } from "./KPICards";
 import { WaterfallChart } from "./WaterfallChart";
-import { SCurveComparison } from "./SCurveComparison";
+import { MultiSCurveDisplay } from "./MultiSCurveDisplay";
 import { EntityImpactGrid } from "./EntityImpactGrid";
 import { ForecastImpactList } from "./ForecastImpactList";
 
@@ -57,6 +57,7 @@ export const ImpactAnalysisDashboard = ({
   } = useImpactAnalysis(
     changeOrderId,
     actualBranchName,
+    "merged",
     { enabled: !!actualBranchName }
   );
 
@@ -99,10 +100,14 @@ export const ImpactAnalysisDashboard = ({
     },
     {
       key: "scurve",
-      label: "S-Curve",
+      label: "S-Curve Comparison",
       children: (
         <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-          <SCurveComparison timeSeries={impactData.time_series} />
+          <MultiSCurveDisplay
+            timeSeries={impactData.time_series}
+            loading={impactLoading}
+            showExport={true}
+          />
         </div>
       ),
     },

--- a/frontend/src/features/change-orders/components/MultiSCurveDisplay.tsx
+++ b/frontend/src/features/change-orders/components/MultiSCurveDisplay.tsx
@@ -1,0 +1,172 @@
+/**
+ * MultiSCurveDisplay Component
+ *
+ * Container component that renders all 4 EVM S-Curve charts (Budget, PV, EV, AC)
+ * in a responsive grid layout for change order impact analysis.
+ *
+ * Context: Used in the ImpactAnalysisDashboard S-Curve tab to display the complete
+ * time-series comparison between Main Branch and Change Order MERGE mode.
+ *
+ * @module features/change-orders/components
+ */
+
+import { useMemo } from "react";
+import { Row, Col, Empty } from "antd";
+import type { TimeSeriesData } from "@/api/generated";
+import { SCurveChart, type SCurveMetric } from "./SCurveChart";
+
+/**
+ * Props for MultiSCurveDisplay component.
+ */
+export interface MultiSCurveDisplayProps {
+  /** Array of time series data for all metrics (budget, pv, ev, ac) */
+  timeSeries: TimeSeriesData[] | undefined;
+  /** Loading state */
+  loading?: boolean;
+  /** Show PNG export button on each chart (default: false) */
+  showExport?: boolean;
+  /** Layout mode: grid (2x2) or stacked (1 column) (default: "grid") */
+  layout?: "grid" | "stacked";
+  /** Additional CSS class name */
+  className?: string;
+}
+
+/**
+ * Chart configuration for each metric.
+ */
+interface ChartConfig {
+  metricName: SCurveMetric;
+  title: string;
+  color?: string;
+}
+
+/**
+ * All 4 EVM metrics to display.
+ */
+const CHART_CONFIGS: ChartConfig[] = [
+  { metricName: "budget", title: "Budget Allocation", color: "#5b8ff9" },
+  { metricName: "pv", title: "Planned Value (PV)", color: "#5b8ff9" },
+  { metricName: "ev", title: "Earned Value (EV)", color: "#5ad8a6" },
+  { metricName: "ac", title: "Actual Cost (AC)", color: "#5d7092" },
+];
+
+/**
+ * Extract TimeSeriesData for a specific metric from the array.
+ *
+ * @param timeSeries - Array of time series data
+ * @param metricName - Metric to extract
+ * @returns TimeSeriesData for the metric, or undefined if not found
+ */
+function extractMetricData(
+  timeSeries: TimeSeriesData[] | undefined,
+  metricName: string,
+): TimeSeriesData | undefined {
+  return timeSeries?.find((ts) => ts.metric_name === metricName);
+}
+
+/**
+ * MultiSCurveDisplay Component
+ *
+ * Renders a responsive grid of 4 S-Curve charts showing Budget, PV, EV, and AC
+ * progression over time with Main Branch vs Change Order MERGE comparison.
+ */
+export const MultiSCurveDisplay = ({
+  timeSeries,
+  loading = false,
+  showExport = false,
+  layout = "grid",
+  className,
+}: MultiSCurveDisplayProps) => {
+  // Extract each metric's data (memoized to avoid recalculation)
+  const metricData = useMemo(() => {
+    const data: Record<string, TimeSeriesData | undefined> = {};
+    CHART_CONFIGS.forEach((config) => {
+      data[config.metricName] = extractMetricData(timeSeries, config.metricName);
+    });
+    return data;
+  }, [timeSeries]);
+
+  // Check if we have any data at all
+  const hasAnyData = CHART_CONFIGS.some(
+    (config) => metricData[config.metricName]?.data_points?.length,
+  );
+
+  // Handle loading state
+  if (loading) {
+    return (
+      <div className={className} style={{ padding: 24 }}>
+        {/* Loading is handled by individual chart components */}
+        <Row gutter={[16, 16]}>
+          {CHART_CONFIGS.map((config) => (
+            <Col key={config.metricName} xs={24} sm={12} lg={12}>
+              <SCurveChart
+                title={config.title}
+                metricName={config.metricName}
+                data={undefined}
+                color={config.color}
+                loading={true}
+                showExport={showExport}
+              />
+            </Col>
+          ))}
+        </Row>
+      </div>
+    );
+  }
+
+  // Handle empty state (no data at all)
+  if (!timeSeries || timeSeries.length === 0 || !hasAnyData) {
+    return (
+      <div
+        className={className}
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          padding: 48,
+        }}
+      >
+        <Empty
+          description="No time-series data available"
+          style={{ margin: 0 }}
+        />
+      </div>
+    );
+  }
+
+  // Determine column span based on layout
+  const getColSpan = () => {
+    if (layout === "stacked") {
+      return { xs: 24, sm: 24, lg: 24 };
+    }
+    return { xs: 24, sm: 12, lg: 12 };
+  };
+
+  const colSpan = getColSpan();
+
+  return (
+    <div className={className}>
+      <Row gutter={[16, 16]}>
+        {CHART_CONFIGS.map((config) => (
+          <Col
+            key={config.metricName}
+            xs={colSpan.xs}
+            sm={colSpan.sm}
+            lg={colSpan.lg}
+          >
+            <SCurveChart
+              title={config.title}
+              metricName={config.metricName}
+              data={metricData[config.metricName]}
+              color={config.color}
+              loading={false}
+              showExport={showExport}
+            />
+          </Col>
+        ))}
+      </Row>
+    </div>
+  );
+};
+
+export default MultiSCurveDisplay;

--- a/frontend/src/features/change-orders/components/SCurveChart.tsx
+++ b/frontend/src/features/change-orders/components/SCurveChart.tsx
@@ -1,0 +1,239 @@
+/**
+ * SCurveChart Component
+ *
+ * Reusable ECharts-based component for displaying time series data with dual-line
+ * comparison between Main Branch and Change Order MERGE mode. Supports Budget,
+ * Planned Value (PV), Earned Value (EV), and Actual Cost (AC) metrics.
+ *
+ * Context: Used by MultiSCurveDisplay to show individual EVM metric progressions
+ * in the change order impact analysis dashboard.
+ *
+ * @module features/change-orders/components
+ */
+
+import React, { useMemo, useRef } from "react";
+import { Card, Typography, Button } from "antd";
+import { DownloadOutlined } from "@ant-design/icons";
+import type { TimeSeriesData } from "@/api/generated";
+import { EChartsBaseChart } from "@/features/evm/components/charts/EChartsBaseChart";
+import {
+  buildTimeSeriesOptions,
+  createCurrencyFormatter,
+  createDateFormatter,
+} from "@/features/evm/utils/echartsConfig";
+import { useEChartsTheme } from "@/features/evm/utils/echartsTheme";
+import type { EChartsOption } from "echarts";
+import type ReactECharts from "echarts-for-react";
+
+const { Title } = Typography;
+
+/**
+ * Supported EVM metrics for S-Curve charts.
+ */
+export type SCurveMetric = "budget" | "pv" | "ev" | "ac";
+
+/**
+ * Props for SCurveChart component.
+ */
+export interface SCurveChartProps {
+  /** Chart title displayed in the card header */
+  title: string;
+  /** Metric name to determine color scheme and data extraction */
+  metricName: SCurveMetric;
+  /** Time series data containing main_value and change_value for each week */
+  data: TimeSeriesData | undefined;
+  /** Optional override color for the change order line */
+  color?: string;
+  /** Chart height in pixels (default: 300) */
+  height?: number;
+  /** Loading state */
+  loading?: boolean;
+  /** Show PNG export button (default: false) */
+  showExport?: boolean;
+  /** Additional CSS class name */
+  className?: string;
+}
+
+/**
+ * Default colors for each EVM metric.
+ */
+const METRIC_COLORS: Record<SCurveMetric, string> = {
+  budget: "#5b8ff9", // Blue
+  pv: "#5b8ff9", // Blue - same as budget
+  ev: "#5ad8a6", // Green
+  ac: "#5d7092", // Gray/Red
+};
+
+/**
+ * Metric labels for display.
+ */
+const METRIC_LABELS: Record<SCurveMetric, string> = {
+  budget: "Budget Allocation",
+  pv: "Planned Value (PV)",
+  ev: "Earned Value (EV)",
+  ac: "Actual Cost (AC)",
+};
+
+/**
+ * Transform TimeSeriesData to ECharts series format.
+ *
+ * @param data - Time series data from API
+ * @returns Array of series objects with name and data points
+ */
+function transformToEChartsSeries(
+  data: TimeSeriesData | undefined,
+): Array<{ name: string; data: Array<[string, number]> }> {
+  if (!data?.data_points || data.data_points.length === 0) {
+    return [];
+  }
+
+  const mainData: Array<[string, number]> = [];
+  const changeData: Array<[string, number]> = [];
+
+  data.data_points.forEach((point) => {
+    // Use week_start directly as ISO string for ECharts
+    const dateStr = point.week_start;
+
+    // Add main value if present (not null or undefined)
+    if (point.main_value !== null && point.main_value !== undefined) {
+      mainData.push([dateStr, Number(point.main_value)]);
+    }
+
+    // Add change value if present (not null or undefined)
+    if (point.change_value !== null && point.change_value !== undefined) {
+      changeData.push([dateStr, Number(point.change_value)]);
+    }
+  });
+
+  return [
+    { name: "Main Branch", data: mainData },
+    { name: "Change Order (MERGE)", data: changeData },
+  ];
+}
+
+/**
+ * SCurveChart Component
+ *
+ * Displays a dual-line S-curve chart comparing Main Branch vs Change Order MERGE
+ * for a single EVM metric. Uses ECharts for consistent styling and behavior.
+ */
+export const SCurveChart = React.forwardRef<
+  ReactECharts | null,
+  SCurveChartProps
+>(
+  (
+    {
+      title,
+      metricName,
+      data,
+      color,
+      height = 300,
+      loading = false,
+      showExport = false,
+      className,
+    },
+    ref,
+  ) => {
+    const chartRef = useRef<ReactECharts | null>(null);
+    const echartsTheme = useEChartsTheme();
+
+    // Get color for this metric (use override if provided)
+    const metricColor = color ?? METRIC_COLORS[metricName];
+
+    // Transform data to ECharts series format
+    const seriesData = useMemo(
+      () => transformToEChartsSeries(data),
+      [data],
+    );
+
+    // Build chart options
+    const chartOption: EChartsOption = useMemo(() => {
+      if (seriesData.length === 0) {
+        return {};
+      }
+
+      return buildTimeSeriesOptions(
+        {
+          chartType: "evm-progression",
+          series: [
+            {
+              name: "Main Branch",
+              data: seriesData[0]?.data ?? [],
+              color: echartsTheme.colors.textSecondary, // Gray for baseline
+            },
+            {
+              name: "Change Order (MERGE)",
+              data: seriesData[1]?.data ?? [],
+              color: metricColor,
+            },
+          ],
+          showZoom: false, // Disabled for smaller charts
+          yFormatter: createCurrencyFormatter("EUR"),
+          xFormatter: createDateFormatter("week"),
+        },
+        echartsTheme,
+      );
+    }, [seriesData, metricColor, echartsTheme]);
+
+    /**
+     * Export chart to PNG.
+     */
+    const handleExport = () => {
+      const chart = chartRef.current?.getEchartsInstance();
+      if (chart) {
+        const url = chart.getDataURL({
+          type: "png",
+          pixelRatio: 2,
+          backgroundColor: "#fff",
+        });
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = `${metricName}-s-curve-${new Date().toISOString().split("T")[0]}.png`;
+        link.click();
+      }
+    };
+
+    // Chart card with optional export button
+    const cardExtra = showExport ? (
+      <Button
+        type="text"
+        icon={<DownloadOutlined />}
+        onClick={handleExport}
+        size="small"
+      >
+        Export
+      </Button>
+    ) : undefined;
+
+    return (
+      <Card
+        title={<Title level={5}>{title}</Title>}
+        extra={cardExtra}
+        loading={loading}
+        className={className}
+        styles={{ body: { padding: 16 } }}
+      >
+        <EChartsBaseChart
+          ref={(node) => {
+            chartRef.current = node;
+            // Handle forwarded ref
+            if (typeof ref === "function") {
+              ref(node);
+            } else if (ref) {
+              ref.current = node;
+            }
+          }}
+          option={chartOption}
+          height={height}
+          loading={loading}
+          showWhenEmpty={false}
+          emptyDescription={`No ${METRIC_LABELS[metricName]} data available`}
+        />
+      </Card>
+    );
+  },
+);
+
+SCurveChart.displayName = "SCurveChart";
+
+export default SCurveChart;

--- a/frontend/src/features/change-orders/index.ts
+++ b/frontend/src/features/change-orders/index.ts
@@ -4,6 +4,8 @@ export { ImpactAnalysisDashboard } from "./components/ImpactAnalysisDashboard";
 export { KPICards } from "./components/KPICards";
 export { WaterfallChart } from "./components/WaterfallChart";
 export { SCurveComparison } from "./components/SCurveComparison";
+export { MultiSCurveDisplay } from "./components/MultiSCurveDisplay";
+export { SCurveChart } from "./components/SCurveChart";
 export { EntityImpactGrid } from "./components/EntityImpactGrid";
 export { ApprovalInfo } from "./components/ApprovalInfo";
 export {


### PR DESCRIPTION
This commit significantly enhances the change order impact analysis S-curve visualization to show complete Earned Value Management (EVM) metrics.

Backend Changes:
- Add time machine support (as_of parameter) for historical queries
- Rewrite _generate_time_series() to return 4 metrics instead of 1:
  * budget: Cumulative budget allocation
  * pv: Planned Value (scheduled work progression)
  * ev: Earned Value (completed work from progress entries)
  * ac: Actual Cost (cumulative spend from cost registrations)
- Add proper temporal filtering with TSTZRANGE queries
- Fix WBE budget_allocation join with branch matching
- Add fallback _generate_simple_budget_series() for projects without schedules

Frontend Changes:
- Add MultiSCurveDisplay container component (4-chart grid layout)
- Add SCurveChart reusable ECharts component with export
- Update ImpactAnalysisDashboard to use new S-curve components

Testing:
- Add test_s_curve_bug_fix.py regression test
- Add test_s_curve_time_series.py with 6 edge case scenarios
- Add EV_INVESTIGATION_REPORT.md documenting root cause analysis

Fixes: S-curve now properly shows differences between main and change branches when WBE budgets are modified, using correct budget_allocation values.