### PR TITLE
feat(ai): add AI chat tab to cost element detail page

### DIFF
--- a/frontend/src/pages/cost-elements/CostElementDetailPage.tsx
+++ b/frontend/src/pages/cost-elements/CostElementDetailPage.tsx
@@ -1,7 +1,8 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { Tabs, theme } from "antd";
+import { Tabs, theme, Space } from "antd";
 import { useEffect } from "react";
 import { Grid } from "antd";
+import { RobotOutlined } from "@ant-design/icons";
 import {
   useCostElement,
   useCostElementBreadcrumb,
@@ -16,6 +17,7 @@ import {
   type CostElementBreadcrumb,
 } from "@/components/cost-elements/CostElementBreadcrumbBuilder";
 import { useTimeMachineStore } from "@/stores/useTimeMachineStore";
+import { ChatInterface } from "@/features/ai/chat/components/ChatInterface";
 
 export const CostElementDetailPage = () => {
   const { token } = theme.useToken();
@@ -94,6 +96,35 @@ export const CostElementDetailPage = () => {
       label: "Progress",
       children: costElement ? (
         <ProgressEntriesTab costElement={costElement} />
+      ) : null,
+    },
+    {
+      key: "chat",
+      label: (
+        <Space>
+          <RobotOutlined />
+          <span>AI Chat</span>
+        </Space>
+      ),
+      children: costElement ? (
+        <>
+          {/* Breadcrumb Navigation */}
+          <CostElementBreadcrumbBuilder
+            breadcrumb={breadcrumb}
+            loading={breadcrumbLoading}
+            isMobile={isMobile}
+          />
+
+          {/* Chat interface with cost element-specific context */}
+          <ChatInterface
+            contextOverride={{
+              type: "cost_element",
+              id: costElement.cost_element_id,
+              project_id: breadcrumb?.project?.project_id,
+              name: costElement.name,
+            }}
+          />
+        </>
       ) : null,
     },
   ];


### PR DESCRIPTION
Add AI Chat tab to CostElementDetailPage following the same pattern as WBEDetailPage. The chat interface is scoped to cost element context using breadcrumb project_id (cost elements don't have direct project_id in their schema, only WBE linkage).