### PR TITLE
feat(evm): wire header card charts to TimeMachine context for branch/…

### DIFF
--- a/backend/app/api/routes/cost_registrations.py
+++ b/backend/app/api/routes/cost_registrations.py
@@ -334,6 +334,15 @@ async def get_budget_status(
 async def get_project_budget_status(
     project_id: UUID,
     branch: str = Query("main", description="Branch context to resolve Project budget"),
+    as_of: datetime | None = Query(
+        None,
+        description="Time travel: get budget status as of this timestamp (ISO 8601)",
+    ),
+    branch_mode: str = Query(
+        "merge",
+        pattern="^(merge|isolated)$",
+        description="Branch mode: merge (fallback to main) or isolated (current branch only)",
+    ),
     service: CostRegistrationService = Depends(get_cost_registration_service),
 ) -> dict[str, Any]:
     """Get project-level budget status (aggregated across all cost elements).
@@ -343,11 +352,11 @@ async def get_project_budget_status(
     budget validation in the cost registration modal.
 
     The total spend is aggregated across all cost registrations in all
-    cost elements belonging to the project.
+    cost elements belonging to the project. Supports time-travel via as_of.
     """
     try:
         budget_status = await service.get_project_budget_status(
-            project_id=project_id, branch=branch
+            project_id=project_id, branch=branch, as_of=as_of, branch_mode=branch_mode
         )
         return {
             "project_id": str(budget_status.project_id),
@@ -371,17 +380,26 @@ async def get_project_budget_status(
 async def get_wbe_budget_status(
     wbe_id: UUID,
     branch: str = Query("main", description="Branch context to resolve WBE budget"),
+    as_of: datetime | None = Query(
+        None,
+        description="Time travel: get budget status as of this timestamp (ISO 8601)",
+    ),
+    branch_mode: str = Query(
+        "merge",
+        pattern="^(merge|isolated)$",
+        description="Branch mode: merge (fallback to main) or isolated (current branch only)",
+    ),
     service: CostRegistrationService = Depends(get_cost_registration_service),
 ) -> dict[str, Any]:
     """Get WBE-level budget status (aggregated across WBE hierarchy).
 
     Returns the WBE budget (sum of cost element budgets in hierarchy),
     total spend across all cost registrations, remaining amount, and
-    percentage used.
+    percentage used. Supports time-travel via as_of.
     """
     try:
         budget_status = await service.get_wbe_budget_status(
-            wbe_id=wbe_id, branch=branch
+            wbe_id=wbe_id, branch=branch, as_of=as_of, branch_mode=branch_mode
         )
         return {
             "wbe_id": str(budget_status.wbe_id),

--- a/backend/app/services/cost_registration_service.py
+++ b/backend/app/services/cost_registration_service.py
@@ -80,7 +80,11 @@ class CostRegistrationService(TemporalService[CostRegistration]):  # type: ignor
         super().__init__(CostRegistration, db)
 
     async def get_project_budget_status(
-        self, project_id: UUID, branch: str = "main"
+        self,
+        project_id: UUID,
+        branch: str = "main",
+        as_of: datetime | None = None,
+        branch_mode: str = "merge",
     ) -> ProjectBudgetStatus:
         """Get project-level budget status (aggregated across all cost elements).
 
@@ -91,6 +95,8 @@ class CostRegistrationService(TemporalService[CostRegistration]):  # type: ignor
         Args:
             project_id: The project to get status for
             branch: Branch context for queries (defaults to "main")
+            as_of: Optional timestamp for time-travel query on cost registrations
+            branch_mode: "merge" (fallback to main) or "isolated" (current branch only)
 
         Returns:
             ProjectBudgetStatus with project_budget, total_spend, remaining, percentage
@@ -153,14 +159,20 @@ class CostRegistrationService(TemporalService[CostRegistration]):  # type: ignor
             .join(WBE, CostElement.wbe_id == WBE.wbe_id)
             .where(
                 WBE.project_id == project_id,
-                func.upper(CostRegistration.valid_time).is_(None),
-                CostRegistration.deleted_at.is_(None),
                 func.upper(CostElement.valid_time).is_(None),
                 CostElement.deleted_at.is_(None),
                 func.upper(WBE.valid_time).is_(None),
                 WBE.deleted_at.is_(None),
             )
         )
+
+        # Apply bitemporal filter to CostRegistration when as_of is provided
+        if as_of is not None:
+            total_spend_stmt = self._apply_bitemporal_filter(total_spend_stmt, as_of)
+        else:
+            total_spend_stmt = total_spend_stmt.where(
+                func.upper(CostRegistration.valid_time).is_(None)
+            ).where(CostRegistration.deleted_at.is_(None))
 
         result = await self.session.execute(total_spend_stmt)
         total_spend = result.scalar_one() or Decimal("0")
@@ -183,7 +195,11 @@ class CostRegistrationService(TemporalService[CostRegistration]):  # type: ignor
         )
 
     async def get_wbe_budget_status(
-        self, wbe_id: UUID, branch: str = "main"
+        self,
+        wbe_id: UUID,
+        branch: str = "main",
+        as_of: datetime | None = None,
+        branch_mode: str = "merge",
     ) -> WBEBudgetStatus:
         """Get WBE-level budget status (aggregated across WBE hierarchy).
 
@@ -193,6 +209,8 @@ class CostRegistrationService(TemporalService[CostRegistration]):  # type: ignor
         Args:
             wbe_id: The WBE to get status for
             branch: Branch context (defaults to "main")
+            as_of: Optional timestamp for time-travel query on cost registrations
+            branch_mode: "merge" (fallback to main) or "isolated" (current branch only)
 
         Returns:
             WBEBudgetStatus with budget, total_spend, remaining, percentage
@@ -251,11 +269,15 @@ class CostRegistrationService(TemporalService[CostRegistration]):  # type: ignor
                 CostRegistration,
                 CostRegistration.cost_element_id == CostElement.cost_element_id,
             )
-            .where(
-                func.upper(CostRegistration.valid_time).is_(None),
-                CostRegistration.deleted_at.is_(None),
-            )
         )
+
+        # Apply bitemporal filter to CostRegistration when as_of is provided
+        if as_of is not None:
+            spend_stmt = self._apply_bitemporal_filter(spend_stmt, as_of)
+        else:
+            spend_stmt = spend_stmt.where(
+                func.upper(CostRegistration.valid_time).is_(None)
+            ).where(CostRegistration.deleted_at.is_(None))
         spend_result = await self.session.execute(spend_stmt)
         total_spend = Decimal(str(spend_result.scalar_one()))
 

--- a/frontend/src/components/projects/ProjectHeaderCard.tsx
+++ b/frontend/src/components/projects/ProjectHeaderCard.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useState } from "react";
-import { Card, Tag, Typography, theme, Row, Col, Progress, Flex } from "antd";
+import { Card, Grid, Tag, Typography, theme, Row, Col, Progress, Flex } from "antd";
 import { ProjectRead } from "@/api/generated";
 import { getProjectStatusColor } from "@/lib/status";
-import { formatDate, formatCurrency } from "@/utils/formatters";
+import { formatDate, formatCompactCurrency } from "@/utils/formatters";
+import { useTimeMachineParams } from "@/contexts/TimeMachineContext";
 
 const { Text, Title } = Typography;
 
@@ -13,12 +14,6 @@ interface ProjectHeaderCardProps {
   actualCosts?: string | number | null;
 }
 
-/**
- * ProjectHeaderCard - Compact card displaying key project information.
- *
- * Shows project code/name, status, and progress rings for time and budget
- * utilization. Optional extraContent slot renders below the progress row.
- */
 export const ProjectHeaderCard = ({
   project,
   loading,
@@ -26,19 +21,22 @@ export const ProjectHeaderCard = ({
   actualCosts,
 }: ProjectHeaderCardProps) => {
   const { token } = theme.useToken();
+  const screens = Grid.useBreakpoint();
+  const isMobile = !screens.md;
+  const { asOf } = useTimeMachineParams();
 
   // control_date is returned by the API but not yet in the generated type
   const controlDate = (project as Record<string, unknown>)
     .control_date as string | null | undefined;
 
-  // Capture current time via useState to satisfy React purity rules.
-  // The initializer runs once on mount; the value stays stable across
-  // re-renders unless the component unmounts and remounts.
   const [nowTime] = useState(() => Date.now());
 
-  const referenceTime = controlDate
-    ? new Date(controlDate).getTime()
-    : nowTime;
+  // Priority: TimeMachine asOf > project control_date > now
+  const referenceTime = asOf
+    ? new Date(asOf).getTime()
+    : controlDate
+      ? new Date(controlDate).getTime()
+      : nowTime;
 
   const timePercent = useMemo(() => {
     if (!project.start_date || !project.end_date) return 0;
@@ -54,7 +52,6 @@ export const ProjectHeaderCard = ({
   const costActual = Number(actualCosts) || 0;
   const costRevenue = Number(project.contract_value) || 0;
 
-  // Inner ring: actual costs vs budget
   const costsPercent = costBudget > 0
     ? Math.min(Math.round((costActual / costBudget) * 100), 100) : 0;
   const costsColor =
@@ -62,12 +59,14 @@ export const ProjectHeaderCard = ({
     : costsPercent > 85 ? token.colorWarning
     : token.colorPrimary;
 
-  // Outer ring: actual costs vs revenue (only when revenue is present)
   const revenueClamped = costRevenue > 0
     ? Math.min(Math.round((costActual / costRevenue) * 100), 100) : 0;
   const revenueColor =
     costRevenue > 0 && costActual <= costRevenue
       ? token.colorSuccess : token.colorError;
+
+  const ringSize = isMobile ? 120 : 160;
+  const innerRingSize = isMobile ? 96 : 128;
 
   return (
     <Card
@@ -79,21 +78,23 @@ export const ProjectHeaderCard = ({
       }}
       styles={{
         body: {
-          padding: token.paddingXL,
+          padding: isMobile ? token.paddingMD : token.paddingXL,
         },
       }}
     >
-      {/* Title row: CODE -- Name left, Status tag right */}
+      {/* Title row */}
       <Flex
         justify="space-between"
-        align="center"
+        align={isMobile ? "flex-start" : "center"}
+        vertical={isMobile}
+        gap={isMobile ? token.marginXS : 0}
         style={{ marginBottom: token.marginMD }}
       >
         <Title
           level={3}
           style={{
             margin: 0,
-            fontSize: token.fontSizeXXL,
+            fontSize: isMobile ? token.fontSizeXL : token.fontSizeXXL,
             fontWeight: token.fontWeightSemiBold,
             color: token.colorText,
           }}
@@ -129,23 +130,24 @@ export const ProjectHeaderCard = ({
         </Typography.Paragraph>
       )}
 
-      {/* Progress rings: Time + Cost */}
+      {/* Progress rings + chart */}
       <Row
         gutter={[token.marginLG, token.marginLG]}
         style={{ marginBottom: token.marginLG }}
+        align="top"
       >
         {/* Time Progress */}
-        <Col xs={24} md={12}>
-          <div style={{ textAlign: "center", padding: token.paddingLG }}>
+        <Col xs={24} sm={12} md={6}>
+          <div style={{ textAlign: "center", padding: token.paddingSM }}>
             <Progress
               type="circle"
               percent={timePercent}
-              size={140}
+              size={isMobile ? 120 : 140}
               format={(percent) => (
                 <div>
                   <div
                     style={{
-                      fontSize: token.fontSizeXL,
+                      fontSize: isMobile ? token.fontSizeLG : token.fontSizeXL,
                       fontWeight: token.fontWeightSemiBold,
                     }}
                   >
@@ -207,23 +209,21 @@ export const ProjectHeaderCard = ({
         </Col>
 
         {/* Cost Progress: dual concentric rings */}
-        <Col xs={24} md={12}>
-          <div style={{ textAlign: "center", padding: token.paddingLG }}>
-            <div style={{ position: "relative", width: 160, height: 160, margin: "0 auto" }}>
-              {/* Outer ring: Costs vs Revenue (only when revenue is present) */}
+        <Col xs={24} sm={12} md={6}>
+          <div style={{ textAlign: "center", padding: token.paddingSM }}>
+            <div style={{ position: "relative", width: ringSize, height: ringSize, margin: "0 auto" }}>
               {costRevenue > 0 && (
                 <div style={{ position: "absolute", inset: 0 }}>
                   <Progress
                     type="circle"
                     percent={revenueClamped}
-                    size={160}
+                    size={ringSize}
                     strokeWidth={6}
                     strokeColor={revenueColor}
                     showInfo={false}
                   />
                 </div>
               )}
-              {/* Inner ring: Actual costs vs Budget */}
               <div style={{
                 position: costRevenue > 0 ? "absolute" : "relative",
                 top: costRevenue > 0 ? 16 : undefined,
@@ -233,7 +233,7 @@ export const ProjectHeaderCard = ({
                 <Progress
                   type="circle"
                   percent={costsPercent}
-                  size={costRevenue > 0 ? 128 : 160}
+                  size={costRevenue > 0 ? innerRingSize : ringSize}
                   strokeWidth={6}
                   strokeColor={costsColor}
                   format={(percent) => (
@@ -249,10 +249,9 @@ export const ProjectHeaderCard = ({
                 />
               </div>
             </div>
-            {/* Legend */}
             <div style={{ marginTop: token.marginMD }}>
               <div>
-                <Text strong>{formatCurrency(costBudget)}</Text>
+                <Text strong>{formatCompactCurrency(costBudget)}</Text>
                 <Text type="secondary" style={{ fontSize: token.fontSizeSM, marginLeft: token.marginXS }}>
                   budget
                 </Text>
@@ -267,7 +266,7 @@ export const ProjectHeaderCard = ({
                   marginRight: token.marginXS,
                 }} />
                 <Text style={{ fontSize: token.fontSizeSM }}>
-                  {formatCurrency(costActual)} costs
+                  {formatCompactCurrency(costActual)} costs
                 </Text>
                 {costBudget > 0 && (
                   <Text type="secondary" style={{ fontSize: token.fontSizeSM, marginLeft: token.marginXS }}>
@@ -286,24 +285,23 @@ export const ProjectHeaderCard = ({
                     marginRight: token.marginXS,
                   }} />
                   <Text style={{ fontSize: token.fontSizeSM }}>
-                    {formatCurrency(costRevenue)} revenue
-                  </Text>
-                  <Text type="secondary" style={{ fontSize: token.fontSizeSM, marginLeft: token.marginXS }}>
-                    ({Math.round((costActual / costRevenue) * 100)}% covered)
+                    {formatCompactCurrency(costRevenue)} revenue
                   </Text>
                 </div>
               )}
             </div>
           </div>
         </Col>
+
+        {/* PV vs EV Trend chart */}
+        {extraContent && (
+          <Col xs={24} sm={24} md={12}>
+            {extraContent}
+          </Col>
+        )}
       </Row>
 
-      {/* Extra content slot (e.g. cost history chart) */}
-      {extraContent && (
-        <div style={{ marginTop: token.paddingLG }}>{extraContent}</div>
-      )}
-
-      {/* Project ID footer - important identifier for users */}
+      {/* Project ID footer */}
       <div
         style={{
           marginTop: token.marginLG,

--- a/frontend/src/components/wbes/WBEHeaderCard.tsx
+++ b/frontend/src/components/wbes/WBEHeaderCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Card, Tag, Typography, theme, Progress, Flex } from "antd";
+import { Card, Grid, Tag, Typography, theme, Progress, Flex, Row, Col } from "antd";
 import { WBERead } from "@/api/generated";
-import { formatCurrency } from "@/utils/formatters";
+import { formatCompactCurrency } from "@/utils/formatters";
 
 const { Text } = Typography;
 
@@ -12,12 +12,6 @@ interface WBEHeaderCardProps {
   extraContent?: React.ReactNode;
 }
 
-/**
- * WBEHeaderCard - Compact card displaying key WBE information.
- *
- * Shows WBE code/name, branch tag, description, cost ring visualization,
- * and optional extra content slot. Matches the ProjectHeaderCard layout pattern.
- */
 export const WBEHeaderCard = ({
   wbe,
   loading,
@@ -25,6 +19,8 @@ export const WBEHeaderCard = ({
   extraContent,
 }: WBEHeaderCardProps) => {
   const { token } = theme.useToken();
+  const screens = Grid.useBreakpoint();
+  const isMobile = !screens.md;
 
   const getBranchColor = (branch: string) => {
     if (branch === "main") return "blue";
@@ -32,7 +28,7 @@ export const WBEHeaderCard = ({
     return "default";
   };
 
-  // Cost ring computations (same pattern as ProjectHeaderCard)
+  // Cost ring computations
   const costBudget = Number(wbe.budget_allocation) || 0;
   const costActual = Number(actualCosts) || 0;
   const costRevenue = Number(wbe.revenue_allocation) || 0;
@@ -50,6 +46,9 @@ export const WBEHeaderCard = ({
     costRevenue > 0 && costActual <= costRevenue
       ? token.colorSuccess : token.colorError;
 
+  const ringSize = isMobile ? 120 : 160;
+  const innerRingSize = isMobile ? 96 : 128;
+
   return (
     <Card
       loading={loading}
@@ -60,21 +59,23 @@ export const WBEHeaderCard = ({
       }}
       styles={{
         body: {
-          padding: token.paddingXL,
+          padding: isMobile ? token.paddingMD : token.paddingXL,
         },
       }}
     >
-      {/* Title row: CODE — Name left, Branch tag right */}
+      {/* Title row */}
       <Flex
         justify="space-between"
-        align="center"
+        align={isMobile ? "flex-start" : "center"}
+        vertical={isMobile}
+        gap={isMobile ? token.marginXS : 0}
         style={{ marginBottom: token.marginMD }}
       >
         <Typography.Title
           level={3}
           style={{
             margin: 0,
-            fontSize: token.fontSizeXXL,
+            fontSize: isMobile ? token.fontSizeXL : token.fontSizeXXL,
             fontWeight: token.fontWeightSemiBold,
             color: token.colorText,
           }}
@@ -110,99 +111,104 @@ export const WBEHeaderCard = ({
         </Typography.Paragraph>
       )}
 
-      {/* Cost Progress: dual concentric rings (reused from ProjectHeaderCard) */}
-      <div style={{ textAlign: "center", padding: token.paddingLG }}>
-        <div style={{ position: "relative", width: 160, height: 160, margin: "0 auto" }}>
-          {/* Outer ring: Costs vs Revenue (only when revenue is present) */}
-          {costRevenue > 0 && (
-            <div style={{ position: "absolute", inset: 0 }}>
-              <Progress
-                type="circle"
-                percent={revenueClamped}
-                size={160}
-                strokeWidth={6}
-                strokeColor={revenueColor}
-                showInfo={false}
-              />
-            </div>
-          )}
-          {/* Inner ring: Actual costs vs Budget */}
-          <div style={{
-            position: costRevenue > 0 ? "absolute" : "relative",
-            top: costRevenue > 0 ? 16 : undefined,
-            left: costRevenue > 0 ? 16 : undefined,
-            margin: costRevenue > 0 ? undefined : "0 auto",
-          }}>
-            <Progress
-              type="circle"
-              percent={costsPercent}
-              size={costRevenue > 0 ? 128 : 160}
-              strokeWidth={6}
-              strokeColor={costsColor}
-              format={(percent) => (
-                <div>
-                  <div style={{ fontSize: token.fontSizeLG, fontWeight: token.fontWeightSemiBold }}>
-                    {percent}%
-                  </div>
-                  <div style={{ fontSize: token.fontSizeXS, color: token.colorTextSecondary }}>
-                    of budget
-                  </div>
+      {/* Cost Progress + chart */}
+      <Row
+        gutter={[token.marginLG, token.marginLG]}
+        style={{ marginBottom: token.marginLG }}
+        align="top"
+      >
+        {/* Cost ring */}
+        <Col xs={24} sm={12} md={6}>
+          <div style={{ textAlign: "center", padding: token.paddingSM }}>
+            <div style={{ position: "relative", width: ringSize, height: ringSize, margin: "0 auto" }}>
+              {costRevenue > 0 && (
+                <div style={{ position: "absolute", inset: 0 }}>
+                  <Progress
+                    type="circle"
+                    percent={revenueClamped}
+                    size={ringSize}
+                    strokeWidth={6}
+                    strokeColor={revenueColor}
+                    showInfo={false}
+                  />
                 </div>
               )}
-            />
-          </div>
-        </div>
-        {/* Legend */}
-        <div style={{ marginTop: token.marginMD }}>
-          <div>
-            <Text strong>{formatCurrency(costBudget)}</Text>
-            <Text type="secondary" style={{ fontSize: token.fontSizeSM, marginLeft: token.marginXS }}>
-              budget
-            </Text>
-          </div>
-          <div style={{ marginTop: token.marginXS }}>
-            <span style={{
-              display: "inline-block",
-              width: 8,
-              height: 8,
-              borderRadius: "50%",
-              background: costsColor,
-              marginRight: token.marginXS,
-            }} />
-            <Text style={{ fontSize: token.fontSizeSM }}>
-              {formatCurrency(costActual)} costs
-            </Text>
-            {costBudget > 0 && (
-              <Text type="secondary" style={{ fontSize: token.fontSizeSM, marginLeft: token.marginXS }}>
-                ({Math.round((costActual / costBudget) * 100)}%)
-              </Text>
-            )}
-          </div>
-          {costRevenue > 0 && (
-            <div style={{ marginTop: token.marginXS }}>
-              <span style={{
-                display: "inline-block",
-                width: 8,
-                height: 8,
-                borderRadius: "50%",
-                background: revenueColor,
-                marginRight: token.marginXS,
-              }} />
-              <Text style={{ fontSize: token.fontSizeSM }}>
-                {formatCurrency(costRevenue)} revenue
-              </Text>
-              <Text type="secondary" style={{ fontSize: token.fontSizeSM, marginLeft: token.marginXS }}>
-                ({Math.round((costActual / costRevenue) * 100)}% covered)
-              </Text>
+              <div style={{
+                position: costRevenue > 0 ? "absolute" : "relative",
+                top: costRevenue > 0 ? 16 : undefined,
+                left: costRevenue > 0 ? 16 : undefined,
+                margin: costRevenue > 0 ? undefined : "0 auto",
+              }}>
+                <Progress
+                  type="circle"
+                  percent={costsPercent}
+                  size={costRevenue > 0 ? innerRingSize : ringSize}
+                  strokeWidth={6}
+                  strokeColor={costsColor}
+                  format={(percent) => (
+                    <div>
+                      <div style={{ fontSize: token.fontSizeLG, fontWeight: token.fontWeightSemiBold }}>
+                        {percent}%
+                      </div>
+                      <div style={{ fontSize: token.fontSizeXS, color: token.colorTextSecondary }}>
+                        of budget
+                      </div>
+                    </div>
+                  )}
+                />
+              </div>
             </div>
-          )}
-        </div>
-      </div>
+            <div style={{ marginTop: token.marginMD }}>
+              <div>
+                <Text strong>{formatCompactCurrency(costBudget)}</Text>
+                <Text type="secondary" style={{ fontSize: token.fontSizeSM, marginLeft: token.marginXS }}>
+                  budget
+                </Text>
+              </div>
+              <div style={{ marginTop: token.marginXS }}>
+                <span style={{
+                  display: "inline-block",
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  background: costsColor,
+                  marginRight: token.marginXS,
+                }} />
+                <Text style={{ fontSize: token.fontSizeSM }}>
+                  {formatCompactCurrency(costActual)} costs
+                </Text>
+                {costBudget > 0 && (
+                  <Text type="secondary" style={{ fontSize: token.fontSizeSM, marginLeft: token.marginXS }}>
+                    ({Math.round((costActual / costBudget) * 100)}%)
+                  </Text>
+                )}
+              </div>
+              {costRevenue > 0 && (
+                <div style={{ marginTop: token.marginXS }}>
+                  <span style={{
+                    display: "inline-block",
+                    width: 8,
+                    height: 8,
+                    borderRadius: "50%",
+                    background: revenueColor,
+                    marginRight: token.marginXS,
+                  }} />
+                  <Text style={{ fontSize: token.fontSizeSM }}>
+                    {formatCompactCurrency(costRevenue)} revenue
+                  </Text>
+                </div>
+              )}
+            </div>
+          </div>
+        </Col>
 
-      {/* Extra content slot (e.g. cost history chart) */}
-      {extraContent && (
-        <div style={{ marginTop: token.paddingLG }}>{extraContent}</div>
-      )}
+        {/* PV vs EV Trend chart */}
+        {extraContent && (
+          <Col xs={24} sm={12} md={18}>
+            {extraContent}
+          </Col>
+        )}
+      </Row>
     </Card>
   );
 };

--- a/frontend/src/features/cost-registration/api/useCostRegistrations.ts
+++ b/frontend/src/features/cost-registration/api/useCostRegistrations.ts
@@ -155,15 +155,19 @@ export const useBudgetStatus = (costElementId: string) => {
  * @returns TanStack Query result with project budget status (project_budget, total_spend, remaining, percentage)
  */
 export const useProjectBudgetStatus = (projectId: string) => {
+  const { mode, branch: tmBranch, asOf } = useTimeMachineParams();
+  const branch = tmBranch || "main";
+
   return useQuery({
-    queryKey: ["project-budget-status", projectId] as const,
+    queryKey: ["project-budget-status", projectId, { branch, asOf, mode }] as const,
     queryFn: async () => {
-      // Call the new project-budget-status endpoint
       return await __request(OpenAPI, {
         method: "GET",
         url: `/api/v1/cost-registrations/project-budget-status/${projectId}`,
         query: {
-          branch: "main",
+          branch,
+          branch_mode: mode === "merged" ? "merge" : "strict",
+          as_of: asOf || undefined,
         },
         errors: { 404: "Project not found", 422: "Validation Error" },
       });
@@ -173,14 +177,19 @@ export const useProjectBudgetStatus = (projectId: string) => {
 };
 
 export const useWBEBudgetStatus = (wbeId: string) => {
+  const { mode, branch: tmBranch, asOf } = useTimeMachineParams();
+  const branch = tmBranch || "main";
+
   return useQuery({
-    queryKey: ["wbe-budget-status", wbeId] as const,
+    queryKey: ["wbe-budget-status", wbeId, { branch, asOf, mode }] as const,
     queryFn: async () => {
       return await __request(OpenAPI, {
         method: "GET",
         url: `/api/v1/cost-registrations/wbe-budget-status/${wbeId}`,
         query: {
-          branch: "main",
+          branch,
+          branch_mode: mode === "merged" ? "merge" : "strict",
+          as_of: asOf || undefined,
         },
         errors: { 404: "WBE not found", 422: "Validation Error" },
       });

--- a/frontend/src/features/cost-registration/components/CostHistoryChart.tsx
+++ b/frontend/src/features/cost-registration/components/CostHistoryChart.tsx
@@ -1,12 +1,12 @@
 /**
  * CostHistoryChart Component
  *
- * Displays cost history trends at cost element, WBE, or project level.
- * Two charts: Burn Rate (bar) and Cumulative Cost Trend (line/S-curve).
+ * Displays Planned Value vs Earned Value at project or WBE level
+ * with weekly resolution.
  */
 
-import { useMemo, useState } from "react";
-import { Card, Radio, Space, Typography } from "antd";
+import { useMemo } from "react";
+import { Card, Typography } from "antd";
 import type { EChartsOption } from "echarts";
 import { EChartsBaseChart } from "@/features/evm/components/charts/EChartsBaseChart";
 import { useEChartsTheme } from "@/features/evm/utils/echartsTheme";
@@ -14,139 +14,82 @@ import {
   createCurrencyFormatter,
   createDateFormatter,
 } from "@/features/evm/utils/echartsConfig";
-import {
-  useAggregatedCosts,
-  useCumulativeCosts,
-} from "@/features/cost-registration/api/useCostRegistrations";
+import { useEVMTimeSeries } from "@/features/evm/api/useEVMMetrics";
+import type { EVMTimeSeriesPoint } from "@/features/evm/types";
 
 const { Title } = Typography;
 
-type CostGranularity = "daily" | "weekly" | "monthly";
 type CostEntityType = "cost_element" | "wbe" | "project";
-
-interface AggregatedCostPoint {
-  period_start: string;
-  total_amount: number;
-}
-
-interface CumulativeCostPoint {
-  registration_date: string;
-  amount: number;
-  cumulative_amount: number;
-}
 
 export interface CostHistoryChartProps {
   entityType: CostEntityType;
   entityId: string;
-  budgetAmount?: number;
   height?: number;
   headless?: boolean;
   delayRender?: boolean;
+  controlDate?: string;
 }
 
-const SIX_MONTHS_AGO = new Date(
-  new Date().setMonth(new Date().getMonth() - 6),
-).toISOString();
-
-const GRANULARITY_MAP: Record<CostGranularity, "day" | "week" | "month"> = {
-  daily: "day",
-  weekly: "week",
-  monthly: "month",
-};
-
-/** Shared dataZoom configuration for cost charts. */
-const DATA_ZOOM: EChartsOption["dataZoom"] = [
-  {
-    type: "slider" as const,
-    bottom: "2%",
-    height: 20,
-    borderColor: "transparent",
-    backgroundColor: "transparent",
-    handleSize: "80%",
-    showDetail: false,
-    brushSelect: true,
-  },
-  {
-    type: "inside" as const,
-    zoomOnMouseWheel: true,
-    moveOnMouseMove: true,
-  },
-];
-
-/** Shared grid configuration for cost charts. */
+/** Grid configuration for the chart. */
 const CHART_GRID = {
   left: "3%",
   right: "3%",
-  bottom: "15%",
-  top: "8%",
+  bottom: "14%",
+  top: "6%",
   containLabel: true,
 };
-
-/**
- * Build a tooltip formatter for cost charts.
- * Renders a colored dot + label + formatted amount.
- */
-const buildCostTooltipFormatter =
-  (
-    label: string,
-    dateFormatter: (v: string) => string,
-    currencyFormatter: (v: number) => string,
-  ) =>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (params: any) => {
-    if (!Array.isArray(params) || params.length === 0) return "";
-    const p = params[0];
-    const dateLabel = dateFormatter(
-      Array.isArray(p.value) ? p.value[0] : p.axisValue,
-    );
-    const amount = Array.isArray(p.value) ? p.value[1] : p.value;
-    return `<div style="font-weight: 600; margin-bottom: 4px;">${dateLabel}</div>
-      <div style="display: flex; justify-content: space-between; gap: 16px;">
-        <span style="display: flex; align-items: center;">
-          <span style="display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: ${p.color}; margin-right: 6px;"></span>
-          ${label}
-        </span>
-        <span style="font-weight: 600;">${currencyFormatter(amount)}</span>
-      </div>`;
-  };
 
 export const CostHistoryChart = ({
   entityType,
   entityId,
-  budgetAmount,
-  height = 300,
+  height = 200,
   headless = false,
   delayRender = false,
+  controlDate,
 }: CostHistoryChartProps) => {
-  const [granularity, setGranularity] = useState<CostGranularity>("weekly");
-
-  const { data: aggregatedData, isLoading: aggregatedLoading, error: aggregatedError } =
-    useAggregatedCosts(entityType, entityId, granularity, SIX_MONTHS_AGO);
-
-  const { data: cumulativeData, isLoading: cumulativeLoading, error: cumulativeError } =
-    useCumulativeCosts(entityType, entityId, SIX_MONTHS_AGO);
+  const { data: tsData, isLoading, error } = useEVMTimeSeries(
+    entityType === "cost_element" ? "cost_element" : entityType,
+    entityId,
+    "week",
+    { controlDate },
+  );
 
   const echartsTheme = useEChartsTheme();
   const currencyFormatter = useMemo(() => createCurrencyFormatter("EUR"), []);
-  const dateFormatter = useMemo(
-    () => createDateFormatter(GRANULARITY_MAP[granularity]),
-    [granularity],
-  );
+  const dateFormatter = useMemo(() => createDateFormatter("week"), []);
 
-  const isLoading = aggregatedLoading || cumulativeLoading;
+  const points = tsData?.points as EVMTimeSeriesPoint[] | undefined;
 
-  // Burn Rate bar chart
-  const burnRateOptions = useMemo<EChartsOption | null>(() => {
-    const data = aggregatedData as AggregatedCostPoint[] | undefined;
-    if (!data || data.length === 0) return null;
+  const chartOptions = useMemo<EChartsOption | null>(() => {
+    if (!points || points.length === 0) return null;
+
+    const pvData = points.map((p) => [p.date, p.pv]);
+    const evData = points.map((p) => [p.date, p.ev]);
+    const acData = points.map((p) => [p.date, p.ac]);
 
     return {
-      color: [echartsTheme.colors.primary],
+      color: [echartsTheme.colors.pv, echartsTheme.colors.ev, echartsTheme.colors.ac],
+      legend: {
+        data: ["PV", "EV", "AC"],
+        bottom: 0,
+        left: "center",
+        itemGap: 16,
+        textStyle: { fontSize: 11, color: echartsTheme.colors.textSecondary },
+      },
       tooltip: {
         ...echartsTheme.tooltipConfig,
         trigger: "axis" as const,
-        axisPointer: { type: "shadow" as const },
-        formatter: buildCostTooltipFormatter("Burn Rate", dateFormatter, currencyFormatter),
+        formatter: (params: { color: string; seriesName: string; value: [string, number] }[]) => {
+          if (!Array.isArray(params) || params.length === 0) return "";
+          const dateLabel = dateFormatter(params[0].value[0]);
+          const rows = params
+            .map(
+              (p) =>
+                `<span style="display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: ${p.color}; margin-right: 6px;"></span>${p.seriesName}<span style="float: right; font-weight: 600; margin-left: 16px;">${currencyFormatter(p.value[1])}</span>`,
+            )
+            .join("<br/>");
+          return `<div style="font-weight: 600; margin-bottom: 4px;">${dateLabel}</div>${rows}`;
+        },
       },
       grid: CHART_GRID,
       xAxis: {
@@ -159,140 +102,69 @@ export const CostHistoryChart = ({
         ...echartsTheme.axisConfig,
         axisLabel: {
           ...echartsTheme.axisConfig.axisLabel,
-          formatter: (v: number) => currencyFormatter(v),
+          formatter: (v: number) => {
+            if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(v % 1_000_000 === 0 ? 0 : 1)}m`;
+            if (v >= 1_000) return `${(v / 1_000).toFixed(v % 1_000 === 0 ? 0 : 1)}k`;
+            return String(v);
+          },
         },
       },
       series: [
         {
-          name: "Burn Rate",
-          type: "bar" as const,
-          data: data.map((d) => [d.period_start, d.total_amount]),
-          itemStyle: { color: echartsTheme.colors.primary, borderRadius: [4, 4, 0, 0] },
-          emphasis: { focus: "series" as const },
-        },
-      ],
-      dataZoom: DATA_ZOOM,
-    };
-  }, [aggregatedData, echartsTheme, currencyFormatter, dateFormatter]);
-
-  // Cumulative Cost line chart
-  const cumulativeOptions = useMemo<EChartsOption | null>(() => {
-    const data = cumulativeData as CumulativeCostPoint[] | undefined;
-    if (!data || data.length === 0) return null;
-
-    return {
-      color: [echartsTheme.colors.ac],
-      tooltip: {
-        ...echartsTheme.tooltipConfig,
-        trigger: "axis" as const,
-        formatter: buildCostTooltipFormatter("Cumulative", dateFormatter, currencyFormatter),
-      },
-      grid: CHART_GRID,
-      xAxis: {
-        type: "time" as const,
-        ...echartsTheme.axisConfig,
-        axisLabel: { ...echartsTheme.axisConfig.axisLabel, formatter: dateFormatter },
-      },
-      yAxis: {
-        type: "value" as const,
-        ...echartsTheme.axisConfig,
-        axisLabel: {
-          ...echartsTheme.axisConfig.axisLabel,
-          formatter: (v: number) => currencyFormatter(v),
-        },
-      },
-      series: [
-        {
-          name: "Cumulative Cost",
+          name: "PV",
           type: "line" as const,
-          data: data.map((d) => [d.registration_date, d.cumulative_amount]),
+          data: pvData,
           smooth: true,
           symbol: "circle" as const,
-          symbolSize: 4,
-          lineStyle: { color: echartsTheme.colors.ac, width: 2 },
-          itemStyle: { color: echartsTheme.colors.ac },
+          symbolSize: 3,
+          lineStyle: { width: 2 },
+          itemStyle: { color: echartsTheme.colors.pv },
+        },
+        {
+          name: "EV",
+          type: "line" as const,
+          data: evData,
+          smooth: true,
+          symbol: "circle" as const,
+          symbolSize: 3,
+          lineStyle: { width: 2 },
+          itemStyle: { color: echartsTheme.colors.ev },
           areaStyle: {
             color: {
               type: "linear" as const,
               x: 0, y: 0, x2: 0, y2: 1,
               colorStops: [
-                { offset: 0, color: echartsTheme.colors.ac + "33" },
+                { offset: 0, color: echartsTheme.colors.ev + "22" },
                 { offset: 1, color: "transparent" },
               ],
             } as const,
           },
-          ...(budgetAmount !== undefined && {
-            markLine: {
-              silent: true,
-              symbol: "none",
-              label: {
-                show: true,
-                position: "end" as const,
-                formatter: `Budget: ${currencyFormatter(budgetAmount)}`,
-                fontSize: 11,
-                color: echartsTheme.colors.error,
-              },
-              lineStyle: {
-                type: "dashed" as const,
-                color: echartsTheme.colors.error,
-                width: 2,
-              },
-              data: [{ yAxis: budgetAmount }],
-            },
-          }),
+        },
+        {
+          name: "AC",
+          type: "line" as const,
+          data: acData,
+          smooth: true,
+          symbol: "circle" as const,
+          symbolSize: 3,
+          lineStyle: { width: 2 },
+          itemStyle: { color: echartsTheme.colors.ac },
         },
       ],
-      dataZoom: DATA_ZOOM,
     };
-  }, [cumulativeData, echartsTheme, currencyFormatter, dateFormatter, budgetAmount]);
-
-  const hasAggregatedData =
-    !!aggregatedData && (aggregatedData as AggregatedCostPoint[]).length > 0;
-  const hasCumulativeData =
-    !!cumulativeData && (cumulativeData as CumulativeCostPoint[]).length > 0;
+  }, [points, echartsTheme, currencyFormatter, dateFormatter]);
 
   const chartContent = (
-    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
-      <div style={{ display: "flex", justifyContent: "flex-end" }}>
-        <Radio.Group
-          value={granularity}
-          onChange={(e) => setGranularity(e.target.value as CostGranularity)}
-          size="small"
-        >
-          <Radio.Button value="daily">Daily</Radio.Button>
-          <Radio.Button value="weekly">Weekly</Radio.Button>
-          <Radio.Button value="monthly">Monthly</Radio.Button>
-        </Radio.Group>
-      </div>
-
-      <div>
-        <Title level={5} style={{ marginBottom: 8 }}>Burn Rate (Costs per Period)</Title>
-        <EChartsBaseChart
-          option={burnRateOptions ?? {}}
-          loading={aggregatedLoading}
-          error={aggregatedError?.message ?? null}
-          height={height}
-          emptyDescription={
-            burnRateOptions
-              ? "No cost data for the selected period"
-              : "No aggregated cost data available"
-          }
-          delayRender={delayRender}
-        />
-      </div>
-
-      <div>
-        <Title level={5} style={{ marginBottom: 8 }}>Cumulative Cost Trend</Title>
-        <EChartsBaseChart
-          option={cumulativeOptions ?? {}}
-          loading={cumulativeLoading}
-          error={cumulativeError?.message ?? null}
-          height={height}
-          emptyDescription="No cumulative cost data available"
-          delayRender={delayRender}
-        />
-      </div>
-    </Space>
+    <div>
+      <EChartsBaseChart
+        option={chartOptions ?? {}}
+        loading={isLoading}
+        error={error?.message ?? null}
+        height={height}
+        emptyDescription="No EVM time-series data available"
+        delayRender={delayRender}
+      />
+    </div>
   );
 
   if (headless) {
@@ -302,7 +174,7 @@ export const CostHistoryChart = ({
   return (
     <Card
       title={<Title level={4} style={{ margin: 0 }}>Cost History</Title>}
-      loading={isLoading && !hasAggregatedData && !hasCumulativeData}
+      loading={isLoading && !points?.length}
     >
       {chartContent}
     </Card>

--- a/frontend/src/features/widgets/definitions/CostHistoryWidget.tsx
+++ b/frontend/src/features/widgets/definitions/CostHistoryWidget.tsx
@@ -73,7 +73,7 @@ const CostHistoryComponent: FC<WidgetComponentProps<CostHistoryConfig>> = ({
 registerWidget<CostHistoryConfig>({
   typeId: widgetTypeId("cost-history"),
   displayName: "Cost History",
-  description: "Burn rate and cumulative cost trends over time",
+  description: "Planned Value vs Earned Value trend over time",
   category: "trend",
   icon: <BarChartOutlined />,
   sizeConstraints: {

--- a/frontend/src/pages/projects/ProjectOverview.tsx
+++ b/frontend/src/pages/projects/ProjectOverview.tsx
@@ -40,6 +40,9 @@ export const ProjectOverview = () => {
 
   const { data: project, isLoading: projectLoading } = useProject(projectId!);
 
+  // control_date is returned by the API but not yet in the generated type
+  const controlDate = (project as Record<string, unknown>)?.control_date as string | null | undefined;
+
   // Fetch actual costs for cost progress ring
   const { data: budgetStatus } = useProjectBudgetStatus(projectId!);
 
@@ -188,8 +191,8 @@ export const ProjectOverview = () => {
                 <CostHistoryChart
                   entityType="project"
                   entityId={projectId}
-                  budgetAmount={project.budget ? Number(project.budget) : undefined}
                   headless
+                  controlDate={controlDate || undefined}
                 />
               ) : undefined
             }

--- a/frontend/src/pages/wbes/WBEOverview.tsx
+++ b/frontend/src/pages/wbes/WBEOverview.tsx
@@ -7,6 +7,7 @@ import {
   useWBEs,
   useCreateWBE,
 } from "@/features/wbes/api/useWBEs";
+import { useProject } from "@/features/projects/api/useProjects";
 import { useWBEBudgetStatus } from "@/features/cost-registration/api/useCostRegistrations";
 import { WBECreate, WBERead } from "@/api/generated";
 import { WBEHeaderCard } from "@/components/wbes/WBEHeaderCard";
@@ -35,6 +36,10 @@ export const WBEOverview = () => {
 
   // WBE data (TanStack Query cache hit — layout already fetches)
   const { data: wbe, isLoading: wbeLoading } = useWBE(wbeId!);
+
+  // Project data for control_date
+  const { data: project } = useProject(projectId!);
+  const controlDate = (project as Record<string, unknown>)?.control_date as string | null | undefined;
 
   // WBE budget status (actual costs vs budget)
   const { data: budgetStatus } = useWBEBudgetStatus(wbeId!);
@@ -82,8 +87,8 @@ export const WBEOverview = () => {
               <CostHistoryChart
                 entityType="wbe"
                 entityId={wbeId}
-                budgetAmount={wbe.budget_allocation ? Number(wbe.budget_allocation) : undefined}
                 headless
+                controlDate={controlDate || undefined}
               />
             ) : undefined
           }


### PR DESCRIPTION
…as_of/branch_mode

Budget status hooks (project and WBE level) now use useTimeMachineParams() instead of hardcoded branch="main". Backend endpoints accept as_of and branch_mode for temporal filtering on cost registration queries. CostHistoryChart passes project control_date through to EVM time-series. Time progress ring responds to TimeMachine slider via asOf.