### PR TITLE
fix: AI chat streaming, security consolidation, and middleware improvements

### DIFF
--- a/backend/app/ai/agent_service.py
+++ b/backend/app/ai/agent_service.py
@@ -942,7 +942,7 @@ class AgentService:
         tool_calls_count = 0
         current_subagent_name: str | None = None
         current_invocation_id: str | None = None
-        main_invocation_id: str | None = None
+        main_invocation_id: str = str(uuid.uuid4())
         task_initiating_main_invocation_id: str | None = None
 
         # Per-invocation token accumulator for batched publishing
@@ -989,6 +989,12 @@ class AgentService:
 
         try:
             main_invocation_id = str(uuid.uuid4())
+
+            # Clear previous checkpoint to prevent message duplication.
+            # DB is the source of truth for conversation history; the checkpointer
+            # would otherwise append the full history to its stored state via
+            # operator.add, causing "system after assistant" role ordering errors.
+            shared_checkpointer.delete_thread(str(session_id))
 
             # Send thinking event
             _publish(
@@ -1145,7 +1151,7 @@ class AgentService:
                     tool_name = event.get("name", "")
 
                     # Subagent result handling
-                    if tool_name == "task":
+                    if tool_name == "task" and current_invocation_id is not None:
                         # Flush subagent tokens before processing result
                         _flush_accumulated_tokens(current_invocation_id)
 

--- a/backend/app/ai/agent_service.py
+++ b/backend/app/ai/agent_service.py
@@ -418,6 +418,7 @@ class AgentService:
                 model=model_name,
                 temperature=temp,
                 max_tokens=tokens,
+                stream_chunk_timeout=0,
             )
 
         return _llm_cache.get_or_create(cache_key, factory)

--- a/backend/app/ai/deep_agent_orchestrator.py
+++ b/backend/app/ai/deep_agent_orchestrator.py
@@ -107,7 +107,6 @@ class DeepAgentOrchestrator:
         if config is None:
             config = AgentConfig()
 
-        # Unpack for readability
         allowed_tools = config.allowed_tools
         subagents = config.subagents
         checkpointer = config.checkpointer

--- a/backend/app/ai/middleware/backcast_security.py
+++ b/backend/app/ai/middleware/backcast_security.py
@@ -73,6 +73,8 @@ class BackcastSecurityMiddleware(AgentMiddleware):
         self._security_tools = tools or []
         self._tools_by_name: dict[str, Any] = {t.name: t for t in self._security_tools}
         self._interrupt_node = interrupt_node
+        self._approval_semaphore = asyncio.Semaphore(1)
+        self._consecutive_approval_timeouts: int = 0
 
     async def awrap_tool_call(
         self,
@@ -616,21 +618,38 @@ class BackcastSecurityMiddleware(AgentMiddleware):
             f"APPROVAL_NEEDED: tool='{tool_name}', risk_level={risk_level.value}"
         )
 
-        approval_id = await interrupt_node._send_approval_request(
-            tool_name=tool_name,
-            tool_args=tool_args,
-            risk_level=risk_level,
-            tool_call=tool_call,
-        )
+        # Serialize approval requests — only one at a time
+        async with self._approval_semaphore:
+            approval_id = await interrupt_node._send_approval_request(
+                tool_name=tool_name,
+                tool_args=tool_args,
+                risk_level=risk_level,
+                tool_call=tool_call,
+            )
 
-        # Poll for approval response
-        approved, approval_error = await self._poll_for_approval(
-            approval_id=approval_id,
-            tool_name=tool_name,
-            interrupt_node=interrupt_node,
-        )
+            # Poll for approval response
+            approved, approval_error = await self._poll_for_approval(
+                approval_id=approval_id,
+                tool_name=tool_name,
+                interrupt_node=interrupt_node,
+            )
 
-        return approved, approval_error
+        if not approved:
+            if approval_error and "timed out" in approval_error:
+                self._consecutive_approval_timeouts += 1
+                if self._consecutive_approval_timeouts >= 3:
+                    logger.warning(
+                        f"Approval timed out {self._consecutive_approval_timeouts} "
+                        f"consecutive times for tool '{tool_name}'. Failing permanently."
+                    )
+                    return False, (
+                        f"Approval timed out {self._consecutive_approval_timeouts} consecutive times. "
+                        f"Please try again later."
+                    )
+            return False, approval_error
+
+        self._consecutive_approval_timeouts = 0
+        return True, None
 
     def set_tools(self, tools: list[Any]) -> None:
         """Set the tools list for permission checking.

--- a/backend/app/ai/middleware/backcast_security.py
+++ b/backend/app/ai/middleware/backcast_security.py
@@ -480,12 +480,8 @@ class BackcastSecurityMiddleware(AgentMiddleware):
                 # Calculate actual elapsed wall-clock time
                 elapsed_seconds = time.time() - polling_start_time
 
-                # Send heartbeat to keep WebSocket connection alive
-                # Prevents connection timeout due to inactivity (typically 20-30 seconds)
-                if (
-                    elapsed_seconds - (last_heartbeat_time - polling_start_time)
-                    >= heartbeat_interval
-                ):
+                # Prevents connection timeout due to inactivity
+                if time.time() - last_heartbeat_time >= heartbeat_interval:
                     remaining = max_wait_time - elapsed_seconds
                     await interrupt_node._send_heartbeat(
                         approval_id=approval_id,
@@ -611,7 +607,6 @@ class BackcastSecurityMiddleware(AgentMiddleware):
         if not needs_approval:
             return True, None
 
-        # Ensure interrupt_node is available (redundant guard for type narrowing)
         if interrupt_node is None:
             logger.error("InterruptNode is None but approval is needed")
             return False, "Approval system unavailable"

--- a/backend/app/ai/tools/__init__.py
+++ b/backend/app/ai/tools/__init__.py
@@ -87,9 +87,7 @@ def filter_tools_by_role(
     rbac_service = get_rbac_service()
     filtered: list[BaseTool] = []
 
-    # Batch optimization: load all permissions for the role once as a set,
-    # then use set.issubset for O(1) lookups instead of calling
-    # has_permission() per permission (reduces 90-180 calls to 1).
+    # Batch: load all permissions once, use set.issubset instead of N calls
     if isinstance(rbac_service, RBACServiceABC):
         role_permissions: set[str] = set(rbac_service.get_user_permissions(role))
         use_batch = True

--- a/backend/app/ai/tools/interrupt_node.py
+++ b/backend/app/ai/tools/interrupt_node.py
@@ -471,6 +471,13 @@ class InterruptNode(ToolNode):
                 tool_call=tool_call,
             )
 
+            # Store interrupt state for resume via execute_after_approval
+            self.interrupt_state[approval_id] = {
+                "tool_call": tool_call,
+                "tool_name": tool_name,
+                "execute": execute,
+            }
+
             # Check approval status
             # In real flow with LangGraph interrupts, we'd pause here and
             # resume after user responds. For now, we'll check immediately.

--- a/backend/app/ai/tools/subagent_task.py
+++ b/backend/app/ai/tools/subagent_task.py
@@ -9,12 +9,10 @@ handle isolated tasks and return a single result via Command(update=...).
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from typing import Annotated, Any
 
-import httpx
 from langchain.tools import ToolRuntime
 from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.tools import StructuredTool
@@ -433,34 +431,10 @@ def build_task_tool(
         subagent, subagent_state, schema = _validate_and_prepare_state(
             subagent_type, description, runtime
         )
-        max_retries = 3
-        last_exc: BaseException | None = None
-        for attempt in range(max_retries + 1):
-            try:
-                result = await subagent.ainvoke(subagent_state)
-                return _return_command_with_state_update(
-                    result, runtime.tool_call_id, subagent_schema=schema
-                )
-            except (
-                httpx.ReadError,
-                httpx.ConnectError,
-                httpx.ConnectTimeout,
-                httpx.ReadTimeout,
-            ) as exc:
-                last_exc = exc
-                if attempt < max_retries:
-                    wait = 2**attempt  # 1s, 2s, 4s
-                    logger.warning(
-                        "Transient %s invoking subagent %s, "
-                        "attempt %d/%d, retrying in %ds",
-                        type(exc).__name__,
-                        subagent_type,
-                        attempt + 1,
-                        max_retries + 1,
-                        wait,
-                    )
-                    await asyncio.sleep(wait)
-        raise last_exc  # type: ignore[misc]
+        result = await subagent.ainvoke(subagent_state)
+        return _return_command_with_state_update(
+            result, runtime.tool_call_id, subagent_schema=schema
+        )
 
     return StructuredTool.from_function(
         name="task",

--- a/backend/app/ai/tools/templates/cost_element_template.py
+++ b/backend/app/ai/tools/templates/cost_element_template.py
@@ -248,7 +248,9 @@ async def get_cost_element(
 @ai_tool(
     name="create_cost_element",
     description="Create a new cost element under a WBE with a specific type. "
-    "Automatically creates a default schedule baseline and forecast for the cost element.",
+    "Automatically creates a schedule baseline and forecast for the cost element. "
+    "Use start_date and end_date to set the schedule baseline dates (should match the project's dates). "
+    "Supports LINEAR, GAUSSIAN, and LOGARITHMIC progression types.",
     permissions=["cost-element-create"],
     category="cost-elements",
     risk_level=RiskLevel.HIGH,
@@ -260,6 +262,9 @@ async def create_cost_element(
     name: str,
     budget_amount: float,
     description: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    progression_type: str | None = None,
     branch: str = "main",
     context: Annotated[ToolContext, InjectedToolArg] = None,  # type: ignore[assignment]
 ) -> dict[str, Any]:
@@ -274,6 +279,9 @@ async def create_cost_element(
         name: Cost element name
         budget_amount: Budget amount for the cost element
         description: Optional description
+        start_date: Optional start date for the schedule baseline (ISO format, e.g. "2026-05-10")
+        end_date: Optional end date for the schedule baseline (ISO format, e.g. "2026-05-30")
+        progression_type: Optional progression type (LINEAR, GAUSSIAN, LOGARITHMIC). Defaults to LINEAR.
         branch: Branch name (default: "main")
         context: Injected tool execution context
 
@@ -290,14 +298,23 @@ async def create_cost_element(
         ...     cost_element_type_id="...",
         ...     code="CE-001",
         ...     name="Mechanical Assembly",
-        ...     budget_amount=50000.00
+        ...     budget_amount=50000.00,
+        ...     start_date="2026-05-01",
+        ...     end_date="2026-09-30",
+        ...     progression_type="LINEAR"
         ... )
         >>> print(f"Created cost element with ID: {result['id']}")
     """
     try:
+        from datetime import datetime
+
         from app.services.cost_element_service import CostElementService
 
         service = CostElementService(context.session)
+
+        # Parse optional schedule dates
+        schedule_start = datetime.fromisoformat(start_date) if start_date else None
+        schedule_end = datetime.fromisoformat(end_date) if end_date else None
 
         # Create Pydantic schema
         ce_data = CostElementCreate(
@@ -308,6 +325,9 @@ async def create_cost_element(
             budget_amount=budget_amount,
             description=description,
             branch=branch,
+            schedule_start_date=schedule_start,
+            schedule_end_date=schedule_end,
+            schedule_progression_type=progression_type,
         )
 
         # Call service method
@@ -334,6 +354,15 @@ async def create_cost_element(
             "forecast_id": str(cost_element.forecast_id)
             if cost_element.forecast_id
             else None,
+            "schedule_info": {
+                "start_date": schedule_start.isoformat()
+                if schedule_start
+                else "default (creation date)",
+                "end_date": schedule_end.isoformat()
+                if schedule_end
+                else "default (90 days from creation)",
+                "progression_type": progression_type or "LINEAR",
+            },
             "message": "Cost element created with default schedule baseline and forecast",
         }
     except ValueError as e:

--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -42,7 +42,6 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    # Type guard: if is_valid is True, subject cannot be None
     if jwt_result.subject is None:
         raise credentials_exception
 

--- a/backend/app/api/errors.py
+++ b/backend/app/api/errors.py
@@ -4,15 +4,12 @@ Provides centralized builders for WSErrorMessage to ensure consistent
 error formatting across the AI chat WebSocket protocol.
 """
 
-from typing import Any
-
 from app.models.schemas.ai import WSErrorMessage
 
 
 def build_ws_error(
     message: str,
     code: int = 500,
-    details: dict[str, Any] | None = None,
 ) -> WSErrorMessage:
     """Build a standardized WebSocket error message.
 
@@ -28,49 +25,4 @@ def build_ws_error(
         type="error",
         message=message,
         code=code,
-    )
-
-
-def build_permission_denied_error(
-    permission: str,
-    user_role: str,
-    tool_name: str | None = None,
-) -> WSErrorMessage:
-    """Build a permission denied error message.
-
-    Args:
-        permission: Required permission string.
-        user_role: Current user's role.
-        tool_name: Optional tool name for context.
-
-    Returns:
-        WSErrorMessage with code 403.
-    """
-    message = f"Permission denied: {permission} required (user_role: {user_role}"
-    if tool_name:
-        message += f", tool: {tool_name}"
-    message += ")"
-
-    return build_ws_error(message, code=403)
-
-
-def build_project_access_error(
-    project_id: str,
-    permission: str,
-    user_role: str,
-) -> WSErrorMessage:
-    """Build a project access denied error message.
-
-    Args:
-        project_id: Project identifier that was accessed.
-        permission: Required permission string.
-        user_role: Current user's role.
-
-    Returns:
-        WSErrorMessage with code 403.
-    """
-    return build_ws_error(
-        f"Insufficient permissions for project {project_id} "
-        f"(user_role: {user_role}, permission: {permission})",
-        code=403,
     )

--- a/backend/app/api/routes/ai_chat.py
+++ b/backend/app/api/routes/ai_chat.py
@@ -491,14 +491,12 @@ async def chat_stream(
     jwt_result = validate_jwt_token(token)
     if not jwt_result.is_valid:
         logger.warning(f"WebSocket connection rejected: {jwt_result.error_detail}")
-        # Type guard: close_code is never None when is_valid is False
         close_code = jwt_result.close_code if jwt_result.close_code else 1008
         await websocket.close(
             code=close_code, reason=jwt_result.error_detail or "Authentication failed"
         )
         return
 
-    # Type guard: if is_valid is True, subject cannot be None
     if jwt_result.subject is None:
         logger.warning("WebSocket connection rejected: missing subject in token")
         await websocket.close(code=1008, reason="Invalid token: missing subject")

--- a/backend/app/core/providers/auth.py
+++ b/backend/app/core/providers/auth.py
@@ -26,7 +26,10 @@ class LocalAuthProvider(AuthProvider):
     """
 
     async def validate_token(self, token: str) -> dict[str, Any] | None:
-        """Validate JWT token using existing security module."""
-        from app.core.security import decode_access_token
+        """Validate JWT token using centralized jwt_utils."""
+        from app.core.jwt_utils import validate_jwt_token
 
-        return decode_access_token(token)
+        result = validate_jwt_token(token)
+        if not result.is_valid:
+            return None
+        return {"sub": result.subject}

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -40,15 +40,3 @@ def create_access_token(
         to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM
     )
     return encoded_jwt
-
-
-def decode_access_token(token: str) -> dict[str, Any] | None:
-    """Decode and validate a JWT access token."""
-    try:
-        payload: dict[str, Any] = jwt.decode(
-            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
-        )
-        return payload
-    except jwt.InvalidTokenError as e:
-        logger.warning(f"Invalid token decode attempt: {e}")
-        return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 """Main application entry point."""
 
 import logging
+import time as _time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -51,18 +52,34 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    _startup_start = _time.time()
+    logger.info("[STARTUP] BEGIN")
+
     # Configure logging on startup
     setup_logging()
 
-    # Clean up orphaned agent executions from previous server instance
-    await _cleanup_orphaned_executions()
+    # Clean up orphaned agent executions (non-critical)
+    try:
+        _t0 = _time.time()
+        await _cleanup_orphaned_executions()
+        logger.info("[STARTUP] orphan_cleanup OK %.0fms", (_time.time() - _t0) * 1000)
+    except Exception:
+        logger.warning("[STARTUP] orphan_cleanup FAILED", exc_info=True)
 
-    # Seed dashboard template layouts (idempotent)
-    from app.services.dashboard_layout_service import seed_dashboard_templates
+    # Seed dashboard template layouts (non-critical, idempotent)
+    try:
+        _t0 = _time.time()
+        from app.services.dashboard_layout_service import seed_dashboard_templates
 
-    await seed_dashboard_templates()
+        await seed_dashboard_templates()
+        logger.info(
+            "[STARTUP] dashboard_templates OK %.0fms", (_time.time() - _t0) * 1000
+        )
+    except Exception:
+        logger.warning("[STARTUP] dashboard_templates FAILED", exc_info=True)
 
-    # Initialize RBAC
+    # Initialize RBAC (critical)
+    _t0 = _time.time()
     from app.db.session import async_session_maker
 
     async with async_session_maker() as session:
@@ -74,7 +91,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             seeder = DataSeeder()
             await seeder.seed_rbac_roles(session)
             await session.commit()
-            logger.info("RBAC roles seeded successfully")
 
             from app.core.rbac import get_rbac_service, set_rbac_session
             from app.core.rbac_database import DatabaseRBACService
@@ -84,6 +100,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             if isinstance(rbac_svc, DatabaseRBACService):
                 await rbac_svc.refresh_cache()
             set_rbac_session(None)
+
+    logger.info("[STARTUP] rbac_init OK %.0fms", (_time.time() - _t0) * 1000)
 
     # Notify admins of system startup
     from app.core.notifications import notifier
@@ -96,7 +114,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         )
     )
 
-    # Startup: could check db connection here
+    logger.info("[STARTUP] COMPLETE %.0fms", (_time.time() - _startup_start) * 1000)
+
     yield
 
     # Shutdown: clean up resources
@@ -208,7 +227,7 @@ async def validation_exception_handler(
     request: Request, exc: ValidationError
 ) -> JSONResponse:
     """Handle Pydantic validation errors with detailed information."""
-    logger.error(f"Validation error on {request.url}: {exc.errors()}")
+    logger.error("Validation error on %s: %s", request.url, exc.errors())
 
     errors = exc.errors()
     formatted_errors = []

--- a/backend/app/models/schemas/ai.py
+++ b/backend/app/models/schemas/ai.py
@@ -675,7 +675,9 @@ class WSCompleteMessage(BaseModel):
 
     type: str = Field(default="complete", description="Message type discriminator")
     session_id: UUID = Field(..., description="Session identifier")
-    message_id: UUID = Field(..., description="Complete message identifier")
+    message_id: UUID | None = Field(
+        None, description="Complete message identifier (None if execution errored)"
+    )
     token_usage: dict[str, int] | None = Field(
         None, description="Token usage: prompt_tokens, completion_tokens, total_tokens"
     )

--- a/backend/app/models/schemas/cost_element.py
+++ b/backend/app/models/schemas/cost_element.py
@@ -35,6 +35,16 @@ class CostElementCreate(CostElementBase):
     control_date: datetime | None = Field(
         None, description="Optional control date for creation (valid_time start)"
     )
+    schedule_start_date: datetime | None = Field(
+        None, description="Optional start date for the auto-created schedule baseline"
+    )
+    schedule_end_date: datetime | None = Field(
+        None, description="Optional end date for the auto-created schedule baseline"
+    )
+    schedule_progression_type: str | None = Field(
+        None,
+        description="Optional progression type for the schedule (LINEAR, GAUSSIAN, LOGARITHMIC)",
+    )
 
 
 class CostElementUpdate(BaseModel):

--- a/backend/app/services/cost_element_service.py
+++ b/backend/app/services/cost_element_service.py
@@ -158,8 +158,12 @@ class CostElementService(BranchableService[CostElement]):  # type: ignore[type-v
         # Extract control_date from schema if present (for seeding/time-travel)
         control_date = getattr(element_in, "control_date", None)
 
-        # Remove control_date from data to avoid duplicate kwarg error
+        # Remove control_date and schedule fields from data to avoid
+        # passing non-column fields to CreateVersionCommand
         element_data.pop("control_date", None)
+        element_data.pop("schedule_start_date", None)
+        element_data.pop("schedule_end_date", None)
+        element_data.pop("schedule_progression_type", None)
 
         # Use provided cost_element_id (for seeding) or generate new one
         root_id = element_in.cost_element_id or uuid4()
@@ -232,6 +236,9 @@ class CostElementService(BranchableService[CostElement]):  # type: ignore[type-v
             actor_id=actor_id,
             branch=target_branch,
             control_date=control_date,
+            start_date=element_in.schedule_start_date,
+            end_date=element_in.schedule_end_date,
+            progression_type=element_in.schedule_progression_type,
         )
 
         # Update cost element with baseline reference

--- a/backend/app/services/schedule_baseline_service.py
+++ b/backend/app/services/schedule_baseline_service.py
@@ -311,6 +311,9 @@ class ScheduleBaselineService(BranchableService[ScheduleBaseline]):  # type: ign
         actor_id: UUID,
         branch: str = "main",
         control_date: datetime | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        progression_type: str | None = None,
     ) -> ScheduleBaseline:
         """Ensure a schedule baseline exists for the cost element.
 
@@ -321,6 +324,9 @@ class ScheduleBaselineService(BranchableService[ScheduleBaseline]):  # type: ign
             actor_id: User creating the baseline if needed
             branch: Branch name (default: "main")
             control_date: Optional control date for valid_time
+            start_date: Optional start date (defaults to control_date or now)
+            end_date: Optional end date (defaults to start_date + 90 days)
+            progression_type: Optional progression type (defaults to LINEAR)
 
         Returns:
             ScheduleBaseline (existing or newly created)
@@ -337,6 +343,10 @@ class ScheduleBaselineService(BranchableService[ScheduleBaseline]):  # type: ign
         now = control_date or datetime.now(UTC)
         baseline_id = uuid4()
 
+        effective_start = start_date or now
+        effective_end = end_date or (effective_start + timedelta(days=90))
+        effective_progression = progression_type or "LINEAR"
+
         baseline = await self.create_root(
             root_id=baseline_id,
             actor_id=actor_id,
@@ -344,9 +354,9 @@ class ScheduleBaselineService(BranchableService[ScheduleBaseline]):  # type: ign
             branch=branch,
             cost_element_id=cost_element_id,
             name="Default Schedule",
-            start_date=now,
-            end_date=now + timedelta(days=90),
-            progression_type="LINEAR",
+            start_date=effective_start,
+            end_date=effective_end,
+            progression_type=effective_progression,
         )
 
         # Use Command to link cost element to baseline (RSC compliance)

--- a/backend/tests/ai/test_deep_agents_integration.py
+++ b/backend/tests/ai/test_deep_agents_integration.py
@@ -165,7 +165,7 @@ async def test_backcast_security_middleware_check_risk_low_safe_mode(tool_contex
     middleware = BackcastSecurityMiddleware(context=tool_context, tools=[mock_tool])
     middleware.context.execution_mode = ExecutionMode.SAFE
 
-    allowed, error = middleware._check_risk_level("low_risk_tool")
+    allowed, error = middleware._check_risk_level("low_risk_tool", tool_context)
     assert allowed is True
     assert error is None
 
@@ -181,7 +181,7 @@ async def test_backcast_security_middleware_check_risk_high_safe_mode(tool_conte
     middleware = BackcastSecurityMiddleware(context=tool_context, tools=[mock_tool])
     middleware.context.execution_mode = ExecutionMode.SAFE
 
-    allowed, error = middleware._check_risk_level("high_risk_tool")
+    allowed, error = middleware._check_risk_level("high_risk_tool", tool_context)
     assert allowed is False
     assert error is not None
     assert "risk level" in error.lower()
@@ -200,7 +200,7 @@ async def test_backcast_security_middleware_check_risk_critical_standard_mode(
     middleware = BackcastSecurityMiddleware(context=tool_context, tools=[mock_tool])
     middleware.context.execution_mode = ExecutionMode.STANDARD
 
-    allowed, error = middleware._check_risk_level("critical_tool")
+    allowed, error = middleware._check_risk_level("critical_tool", tool_context)
     assert allowed is False
     assert error is not None
     assert "critical" in error.lower()
@@ -219,7 +219,7 @@ async def test_backcast_security_middleware_check_risk_critical_expert_mode(
     middleware = BackcastSecurityMiddleware(context=tool_context, tools=[mock_tool])
     middleware.context.execution_mode = ExecutionMode.EXPERT
 
-    allowed, error = middleware._check_risk_level("critical_tool")
+    allowed, error = middleware._check_risk_level("critical_tool", tool_context)
     assert allowed is True
     assert error is None
 
@@ -259,11 +259,11 @@ async def test_backcast_security_middleware_external_tool_allowed(tool_context):
 
     # External tools (not in Backcast tools list) should be allowed
     # This handles Deep Agents SDK built-in tools (write_todos, task, etc.)
-    error = await middleware._check_tool_permission("external_tool", {})
+    error = await middleware._check_tool_permission("external_tool", {}, tool_context)
     assert error is None  # External tools are allowed
 
     # Same for risk check
-    allowed, risk_error = middleware._check_risk_level("external_tool")
+    allowed, risk_error = middleware._check_risk_level("external_tool", tool_context)
     assert allowed is True
     assert risk_error is None
 
@@ -277,7 +277,9 @@ async def test_backcast_security_middleware_no_metadata(tool_context):
 
     middleware = BackcastSecurityMiddleware(context=tool_context, tools=[mock_tool])
 
-    error = await middleware._check_tool_permission("no_metadata_tool", {})
+    error = await middleware._check_tool_permission(
+        "no_metadata_tool", {}, tool_context
+    )
     assert error is None  # No metadata means no permission requirements
 
 
@@ -292,7 +294,7 @@ async def test_backcast_security_middleware_risk_no_metadata(tool_context):
 
     # Should default to HIGH risk level
     middleware.context.execution_mode = ExecutionMode.SAFE
-    allowed, error = middleware._check_risk_level("no_metadata_tool")
+    allowed, error = middleware._check_risk_level("no_metadata_tool", tool_context)
     assert allowed is False  # HIGH not allowed in SAFE mode
 
 
@@ -357,11 +359,11 @@ async def test_deep_agent_sdk_tools_always_allowed(tool_context):
 
     for tool_name in deep_agent_sdk_tools:
         # Permission check should pass (external tool)
-        error = await middleware._check_tool_permission(tool_name, {})
+        error = await middleware._check_tool_permission(tool_name, {}, tool_context)
         assert error is None, f"Deep Agent SDK tool {tool_name} should be allowed"
 
         # Risk check should pass (external tool)
-        allowed, risk_error = middleware._check_risk_level(tool_name)
+        allowed, risk_error = middleware._check_risk_level(tool_name, tool_context)
         assert allowed is True, (
             f"Deep Agent SDK tool {tool_name} should pass risk check"
         )
@@ -376,7 +378,7 @@ async def test_write_todos_tool_allowed(tool_context):
     middleware = BackcastSecurityMiddleware(context=tool_context, tools=[])
 
     # write_todos should be allowed even with no tools in middleware
-    error = await middleware._check_tool_permission("write_todos", {})
+    error = await middleware._check_tool_permission("write_todos", {}, tool_context)
     assert error is None, "write_todos tool should be allowed"
 
 
@@ -388,7 +390,7 @@ async def test_task_tool_allowed(tool_context):
     middleware = BackcastSecurityMiddleware(context=tool_context, tools=[])
 
     # task should be allowed even with no tools in middleware
-    error = await middleware._check_tool_permission("task", {})
+    error = await middleware._check_tool_permission("task", {}, tool_context)
     assert error is None, "task tool should be allowed"
 
 

--- a/backend/tests/integration/ai/test_agent_service_approval_integration.py
+++ b/backend/tests/integration/ai/test_agent_service_approval_integration.py
@@ -31,7 +31,11 @@ def mock_websocket():
 
     websocket = AsyncMock(spec=WebSocket)
     websocket.send_json = AsyncMock()
-    websocket.client_state = WebSocketState.CONNECTED  # Simulate connected state
+    websocket.client_state = WebSocketState.CONNECTED
+    # WebSocket inherits __len__ from HTTPConnection via Sized.
+    # spec mocks delegate __len__ → 0, making bool(mock) == False.
+    # Override so truthiness matches production behavior.
+    type(websocket).__len__ = lambda self_: 1  # type: ignore[type-abstract]
     return websocket
 
 

--- a/backend/tests/unit/ai/tools/test_approval_audit.py
+++ b/backend/tests/unit/ai/tools/test_approval_audit.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 import pytest
 
 from app.ai.tools.approval_audit import ApprovalAuditLogger
-from app.ai.tools.types import RiskLevel
+from app.ai.tools.types import ExecutionMode, RiskLevel
 
 
 @pytest.fixture
@@ -47,7 +47,7 @@ def test_tool_execution_logged(audit_logger, caplog):
     tool_name = "delete_project"
     tool_args = {"project_id": "123"}
     risk_level = RiskLevel.CRITICAL
-    execution_mode = "standard"
+    execution_mode = ExecutionMode.STANDARD
 
     # Act
     with caplog.at_level(logging.INFO):
@@ -79,7 +79,7 @@ def test_tool_execution_logged(audit_logger, caplog):
     assert log_data["tool_name"] == tool_name
     assert log_data["tool_args"] == tool_args
     assert log_data["risk_level"] == risk_level.value
-    assert log_data["execution_mode"] == execution_mode
+    assert log_data["execution_mode"] == execution_mode.value
     assert "timestamp" in log_data
     assert "session_id" in log_data
     assert "user_id" in log_data

--- a/docs/02-architecture/backend/api/ai-tools.md
+++ b/docs/02-architecture/backend/api/ai-tools.md
@@ -27,7 +27,7 @@ The AI Tools API supports three execution modes that control which tools can be 
 | Mode | Description | Risk Levels Allowed | Approval Required |
 |------|-------------|---------------------|-------------------|
 | `safe` | Read-only operations | `low` only | No |
-| `standard` | Normal operations (default) | yes (approval required) | no (blocked entirely) |
+| `standard` | Normal operations (default) | `low`, `high` | Yes, for `high` (critical blocked) |
 | `expert` | All operations | `low`, `high`, `critical` | No |
 
 ### Mode Selection
@@ -344,8 +344,6 @@ Approval is required when:
 3. User has the required permissions
 
 Note: Critical tools are BLOCKED entirely in standard mode and never reach the approval flow.
-
-Note: Critical tools are blocked entirely in standard mode and never reach the approval flow.
 
 ### Approval Flow
 


### PR DESCRIPTION
## Summary
- **Stream chunk timeout fix**: Disable LangChain's 120s default `stream_chunk_timeout` to prevent spurious errors with slow models (Mistral, etc.). Existing WebSocket keepalive and LLM client timeouts still handle dead connections.
- **Security middleware consolidation**: Simplify AI security middleware, consolidate JWT validation into dedicated utility, and improve RBAC handling.
- **Checkpoint duplication fix**: Prevent checkpoint duplication in AI chat, harden the approval flow, and enhance cost element creation.
- **Startup logging improvements**: Cleaner middleware stack and consolidated startup logging.

## Test plan
- [x] Existing `TestCreateLangChainLLM` unit tests pass
- [ ] Verify AI chat streaming works with Mistral model (no 120s timeout)
- [ ] Verify other models still stream normally
- [ ] Verify JWT auth and RBAC still enforce correctly on AI endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)