### PR TITLE
AI agent architecture overhaul — supervisor orchestrator, briefing system, streaming fixes

### DIFF
--- a/backend/app/ai/agent_service.py
+++ b/backend/app/ai/agent_service.py
@@ -35,7 +35,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai.briefing import BriefingDocument
-from app.ai.config import AgentConfig
+from app.ai.config import AgentConfig, OrchestratorMode
 from app.ai.deep_agent_orchestrator import DeepAgentOrchestrator
 from app.ai.execution.agent_event import AgentEvent
 from app.ai.execution.agent_event_bus import AgentEventBus
@@ -50,6 +50,7 @@ from app.ai.graph_cache import (
 )
 from app.ai.subagent_compiler import DEFAULT_SYSTEM_PROMPT
 from app.ai.subagents import get_all_subagents
+from app.ai.supervisor_orchestrator import SupervisorOrchestrator
 from app.ai.telemetry import (
     initialize_telemetry,
     trace_context,
@@ -78,18 +79,8 @@ from app.models.schemas.ai import (
     AIChatResponse,
     AIConversationMessagePublic,
     PlanningStep,
-    WSAgentCompleteMessage,
-    WSAgentTransitionMessage,
     WSBriefingMessage,
     WSCompleteMessage,
-    WSContentResetMessage,
-    WSPlanningMessage,
-    WSSubagentMessage,
-    WSSubagentResultMessage,
-    WSThinkingMessage,
-    WSTokenBatchMessage,
-    WSToolCallMessage,
-    WSToolResultMessage,
 )
 from app.services.ai_config_service import AIConfigService
 
@@ -539,24 +530,30 @@ class AgentService:
             logger.info(f"[GRAPH_COMPILE] Compiling new graph for session {session_id}")
             graph_creation_start = time.time()
 
-            orchestrator = DeepAgentOrchestrator(
-                model=llm,
-                context=tool_context,
-                system_prompt=system_prompt,
-                enable_subagents=enable_subagents,
-                interrupt_node=None,  # Don't bake InterruptNode into graph
+            agent_config = AgentConfig(
+                allowed_tools=None,
+                checkpointer=shared_checkpointer,
+                context_schema=BackcastRuntimeContext,
+                assistant_role=assistant_role,
+                user_role=user_role,
             )
 
-            graph = orchestrator.create_agent(
-                config=AgentConfig(
-                    allowed_tools=None,  # RBAC role filtering only
-                    checkpointer=shared_checkpointer,
-                    context_schema=BackcastRuntimeContext,
-                    assistant_role=assistant_role,
-                    user_role=user_role,
-                    use_supervisor=settings.AI_ORCHESTRATOR == "supervisor",
-                ),
-            )
+            if settings.AI_ORCHESTRATOR == OrchestratorMode.SUPERVISOR:
+                orchestrator = SupervisorOrchestrator(
+                    model=llm,
+                    context=tool_context,
+                    system_prompt=system_prompt,
+                )
+                graph = orchestrator.create_supervisor_graph(agent_config)
+            else:
+                orchestrator = DeepAgentOrchestrator(
+                    model=llm,
+                    context=tool_context,
+                    system_prompt=system_prompt,
+                    enable_subagents=enable_subagents,
+                    interrupt_node=None,
+                )
+                graph = orchestrator.create_agent(agent_config)
 
             graph_creation_duration_ms = (time.time() - graph_creation_start) * 1000
             logger.info(
@@ -982,6 +979,22 @@ class AgentService:
         task_initiating_main_invocation_id: str | None = None
         last_entered_agent: str | None = None
 
+        # Event types that the dispatch loop actually handles.
+        # Skipping the rest (~40-60% of LangGraph events) avoids
+        # unnecessary CPU work in the hot streaming path.
+        _HANDLED_EVENTS = frozenset(
+            {
+                "on_chain_start",
+                "on_chain_end",
+                "on_chat_model_stream",
+                "on_chat_model_end",
+                "on_tool_start",
+                "on_tool_end",
+                "on_tool_error",
+                "on_end",
+            }
+        )
+
         # Per-invocation token accumulator for batched publishing
         _token_accumulator: dict[str, list[str]] = {}
 
@@ -1005,15 +1018,56 @@ class AgentService:
             concatenated = "".join(buffered)
             _publish(
                 "token_batch",
-                WSTokenBatchMessage(
-                    type="token_batch",
-                    tokens=concatenated,
-                    session_id=str(session_id),
-                    source="subagent" if current_subagent_name else "main",
-                    subagent_name=current_subagent_name,
-                    invocation_id=invocation_id,
+                {
+                    "type": "token_batch",
+                    "tokens": concatenated,
+                    "session_id": str(session_id),
+                    "source": "subagent" if current_subagent_name else "main",
+                    "subagent_name": current_subagent_name,
+                    "invocation_id": invocation_id,
+                },
+            )
+
+        def _publish_briefing_update(
+            chain_output: Any,
+            chain_name: str,
+            *,
+            log_label: str | None = None,
+        ) -> None:
+            """Extract briefing data from a chain output and publish a briefing_update event."""
+            if (
+                not isinstance(chain_output, dict)
+                or "briefing_data" not in chain_output
+            ):
+                return
+            briefing_data = chain_output.get("briefing_data") or {}
+            try:
+                briefing_md = BriefingDocument.model_validate(
+                    briefing_data
+                ).to_markdown()
+            except Exception:
+                return
+            if not briefing_md:
+                return
+            completed = chain_output.get("completed_specialists", set())
+            completed_list = sorted(completed) if isinstance(completed, set) else []
+            _publish(
+                "briefing_update",
+                WSBriefingMessage(
+                    type="briefing_update",
+                    briefing=briefing_md,
+                    specialist_name=chain_name,
+                    completed_specialists=completed_list,
                 ).model_dump(mode="json"),
             )
+            if log_label:
+                logger.info(
+                    "[%s] name=%s | sections=%d | completed=%s",
+                    log_label,
+                    chain_name,
+                    len(briefing_data.get("sections", [])),
+                    completed_list,
+                )
 
         # Background task to flush tokens periodically for real-time streaming
         async def _periodic_flush() -> None:
@@ -1042,10 +1096,7 @@ class AgentService:
             # NOTE: No checkpoint deletion here - will delete after saving final briefing
 
             # Send thinking event
-            _publish(
-                "thinking",
-                WSThinkingMessage().model_dump(mode="json"),
-            )
+            _publish("thinking", {"type": "thinking"})
 
             # Retry loop for transient network errors during streaming
             max_retries = 2
@@ -1078,6 +1129,8 @@ class AgentService:
                         events_processed += 1
                         event_type = event.get("event", "")
                         data = event.get("data", {})
+                        if event_type not in _HANDLED_EVENTS:
+                            continue
                         # Handle agent transitions in supervisor graph
                         # When a specialist subgraph node starts/ends, detect by chain name
                         chain_name = event.get("name", "")
@@ -1099,12 +1152,12 @@ class AgentService:
                                 last_entered_agent = chain_name
                                 _publish(
                                     "agent_transition",
-                                    WSAgentTransitionMessage(
-                                        type="agent_transition",
-                                        agent_name=chain_name,
-                                        direction="enter",
-                                        invocation_id=current_invocation_id,
-                                    ).model_dump(mode="json"),
+                                    {
+                                        "type": "agent_transition",
+                                        "agent_name": chain_name,
+                                        "direction": "enter",
+                                        "invocation_id": current_invocation_id,
+                                    },
                                 )
                         elif (
                             event_type == "on_chain_end"
@@ -1116,43 +1169,17 @@ class AgentService:
                                 and "briefing_data" in chain_output
                             )
                             if is_briefing_output:
-                                briefing_data = chain_output.get("briefing_data", {})
-                                briefing_md = ""
-                                if briefing_data:
-                                    try:
-                                        briefing_md = BriefingDocument.model_validate(
-                                            briefing_data
-                                        ).to_markdown()
-                                    except Exception:
-                                        briefing_md = ""
-                                if briefing_md:
-                                    completed = chain_output.get(
-                                        "completed_specialists", set()
-                                    )
-                                    completed_list = (
-                                        sorted(completed)
-                                        if isinstance(completed, set)
-                                        else []
-                                    )
-                                    _publish(
-                                        "briefing_update",
-                                        WSBriefingMessage(
-                                            type="briefing_update",
-                                            briefing=briefing_md,
-                                            specialist_name=chain_name,
-                                            completed_specialists=completed_list,
-                                        ).model_dump(mode="json"),
-                                    )
+                                _publish_briefing_update(chain_output, chain_name)
 
                                 # Also emit agent transition exit (first end is inner graph)
                                 _publish(
                                     "agent_transition",
-                                    WSAgentTransitionMessage(
-                                        type="agent_transition",
-                                        agent_name=chain_name,
-                                        direction="exit",
-                                        invocation_id=current_invocation_id,
-                                    ).model_dump(mode="json"),
+                                    {
+                                        "type": "agent_transition",
+                                        "agent_name": chain_name,
+                                        "direction": "exit",
+                                        "invocation_id": current_invocation_id,
+                                    },
                                 )
                                 current_subagent_name = None
                                 current_invocation_id = None
@@ -1166,92 +1193,19 @@ class AgentService:
                             event_type == "on_chain_end" and chain_name == "supervisor"
                         ):
                             chain_output = data.get("output", {})
-                            if (
-                                isinstance(chain_output, dict)
-                                and "briefing_data" in chain_output
-                            ):
-                                briefing_data = chain_output.get("briefing_data", {})
-                                briefing_md = ""
-                                if briefing_data:
-                                    try:
-                                        briefing_md = BriefingDocument.model_validate(
-                                            briefing_data
-                                        ).to_markdown()
-                                    except Exception:
-                                        briefing_md = ""
-                                if briefing_md:
-                                    completed = chain_output.get(
-                                        "completed_specialists", set()
-                                    )
-                                    completed_list = (
-                                        sorted(completed)
-                                        if isinstance(completed, set)
-                                        else []
-                                    )
-                                    _publish(
-                                        "briefing_update",
-                                        WSBriefingMessage(
-                                            type="briefing_update",
-                                            briefing=briefing_md,
-                                            specialist_name="supervisor",
-                                            completed_specialists=completed_list,
-                                        ).model_dump(mode="json"),
-                                    )
-                                    logger.info(
-                                        "[SUPERVISOR_END] Sent briefing with %d sections, %d completed specialists",
-                                        len(briefing_data.get("sections", [])),
-                                        len(completed_list),
-                                    )
+                            _publish_briefing_update(
+                                chain_output, "supervisor", log_label="SUPERVISOR_END"
+                            )
 
                         # Handle initialize_briefing node completion - send briefing to frontend
                         elif event_type == "on_chain_end":
                             chain_output = data.get("output", {})
-                            # Check if this is the initialize_briefing node by checking output
-                            if (
-                                isinstance(chain_output, dict)
-                                and "briefing_data" in chain_output
-                            ):
-                                # This could be initialize_briefing, supervisor, or a specialist
-                                # For specialists, this is handled above
-                                # For initialize_briefing and supervisor, handle here
-                                if chain_name not in SPECIALIST_AGENT_NAMES:
-                                    briefing_data = chain_output.get(
-                                        "briefing_data", {}
-                                    )
-                                    briefing_md = ""
-                                    if briefing_data:
-                                        try:
-                                            briefing_md = (
-                                                BriefingDocument.model_validate(
-                                                    briefing_data
-                                                ).to_markdown()
-                                            )
-                                        except Exception:
-                                            briefing_md = ""
-                                    if briefing_md:
-                                        completed = chain_output.get(
-                                            "completed_specialists", set()
-                                        )
-                                        completed_list = (
-                                            sorted(completed)
-                                            if isinstance(completed, set)
-                                            else []
-                                        )
-                                        _publish(
-                                            "briefing_update",
-                                            WSBriefingMessage(
-                                                type="briefing_update",
-                                                briefing=briefing_md,
-                                                specialist_name="supervisor",
-                                                completed_specialists=completed_list,
-                                            ).model_dump(mode="json"),
-                                        )
-                                        logger.info(
-                                            "[CHAIN_END_NON_SPECIALIST] name=%s | sections=%d | completed=%s",
-                                            chain_name,
-                                            len(briefing_data.get("sections", [])),
-                                            completed_list,
-                                        )
+                            if chain_name not in SPECIALIST_AGENT_NAMES:
+                                _publish_briefing_update(
+                                    chain_output,
+                                    "supervisor",
+                                    log_label="CHAIN_END_NON_SPECIALIST",
+                                )
 
                         # Handle token streaming
                         if event_type == "on_chat_model_stream":
@@ -1347,14 +1301,19 @@ class AgentService:
                                         estimated_total_steps = len(steps)
                                 _publish(
                                     "planning",
-                                    WSPlanningMessage(
-                                        type="planning",
-                                        plan=plan,
-                                        steps=steps,
-                                        step_number=current_step,
-                                        total_steps=estimated_total_steps,
-                                        invocation_id=main_invocation_id,
-                                    ).model_dump(mode="json"),
+                                    {
+                                        "type": "planning",
+                                        "plan": plan,
+                                        "steps": [
+                                            {"text": s.text, "done": s.done}
+                                            for s in steps
+                                        ]
+                                        if steps
+                                        else None,
+                                        "step_number": current_step,
+                                        "total_steps": estimated_total_steps,
+                                        "invocation_id": main_invocation_id,
+                                    },
                                 )
 
                             # Subagent delegation event
@@ -1372,29 +1331,29 @@ class AgentService:
                                 if subagent_type:
                                     _publish(
                                         "subagent",
-                                        WSSubagentMessage(
-                                            type="subagent",
-                                            subagent=subagent_type,
-                                            message=description,
-                                            step_number=current_step,
-                                            total_steps=estimated_total_steps,
-                                            invocation_id=current_invocation_id,
-                                        ).model_dump(mode="json"),
+                                        {
+                                            "type": "subagent",
+                                            "subagent": subagent_type,
+                                            "message": description,
+                                            "step_number": current_step,
+                                            "total_steps": estimated_total_steps,
+                                            "invocation_id": current_invocation_id,
+                                        },
                                     )
 
                             # Standard tool_call event
                             _publish(
                                 "tool_call",
-                                WSToolCallMessage(
-                                    type="tool_call",
-                                    tool=tool_name,
-                                    args=tool_input,
-                                    step_number=current_step,
-                                    total_steps=estimated_total_steps,
-                                    invocation_id=current_invocation_id
+                                {
+                                    "type": "tool_call",
+                                    "tool": tool_name,
+                                    "args": tool_input,
+                                    "step_number": current_step,
+                                    "total_steps": estimated_total_steps,
+                                    "invocation_id": current_invocation_id
                                     if current_subagent_name
                                     else main_invocation_id,
-                                ).model_dump(mode="json"),
+                                },
                             )
 
                         # Handle tool end
@@ -1479,33 +1438,33 @@ class AgentService:
 
                                     _publish(
                                         "subagent_result",
-                                        WSSubagentResultMessage(
-                                            type="subagent_result",
-                                            subagent_name=current_subagent_name
+                                        {
+                                            "type": "subagent_result",
+                                            "subagent_name": current_subagent_name
                                             or "subagent",
-                                            content=subagent_content,
-                                            invocation_id=current_invocation_id,
-                                        ).model_dump(mode="json"),
+                                            "content": subagent_content,
+                                            "invocation_id": current_invocation_id,
+                                        },
                                     )
 
                                 # Subagent completion
                                 _publish(
                                     "agent_complete",
-                                    WSAgentCompleteMessage(
-                                        type="agent_complete",
-                                        agent_type="subagent",
-                                        invocation_id=current_invocation_id,
-                                        agent_name=current_subagent_name,
-                                    ).model_dump(mode="json"),
+                                    {
+                                        "type": "agent_complete",
+                                        "agent_type": "subagent",
+                                        "invocation_id": current_invocation_id,
+                                        "agent_name": current_subagent_name,
+                                    },
                                 )
 
                                 # Content reset after subagent
                                 _publish(
                                     "content_reset",
-                                    WSContentResetMessage(
-                                        type="content_reset",
-                                        reason="subagent_completed",
-                                    ).model_dump(mode="json"),
+                                    {
+                                        "type": "content_reset",
+                                        "reason": "subagent_completed",
+                                    },
                                 )
 
                                 current_subagent_name = None
@@ -1545,14 +1504,14 @@ class AgentService:
 
                             _publish(
                                 "tool_result",
-                                WSToolResultMessage(
-                                    type="tool_result",
-                                    tool=tool_name,
-                                    result=jsonable_encoder(tool_result_dict),
-                                    invocation_id=current_invocation_id
+                                {
+                                    "type": "tool_result",
+                                    "tool": tool_name,
+                                    "result": jsonable_encoder(tool_result_dict),
+                                    "invocation_id": current_invocation_id
                                     if current_subagent_name
                                     else main_invocation_id,
-                                ).model_dump(mode="json"),
+                                },
                             )
 
                         # Handle tool error
@@ -1571,14 +1530,14 @@ class AgentService:
 
                                 _publish(
                                     "tool_result",
-                                    WSToolResultMessage(
-                                        type="tool_result",
-                                        tool=tool_name,
-                                        result=jsonable_encoder(error_result_dict),
-                                        invocation_id=current_invocation_id
+                                    {
+                                        "type": "tool_result",
+                                        "tool": tool_name,
+                                        "result": jsonable_encoder(error_result_dict),
+                                        "invocation_id": current_invocation_id
                                         if current_subagent_name
                                         else main_invocation_id,
-                                    ).model_dump(mode="json"),
+                                    },
                                 )
 
                         # Handle completion
@@ -1612,9 +1571,7 @@ class AgentService:
                             {"configurable": {"thread_id": str(session_id)}}
                         )
                         if checkpoint_state:
-                            channel_values = checkpoint_state.get(
-                                "channel_values", {}
-                            )
+                            channel_values = checkpoint_state.get("channel_values", {})
                             persist_briefing: dict[str, Any] | None = cast(
                                 Any, channel_values.get("briefing_data")
                             )
@@ -1748,6 +1705,12 @@ class AgentService:
             invocation_ids_in_order = list(main_agent_segments.keys())
             total_main_segments = len(invocation_ids_in_order)
             assistant_msg = None
+            logger.info(
+                "[MSG_SAVE] Saving assistant messages for session %s: %d segments, invocation_ids=%s",
+                session_id,
+                total_main_segments,
+                invocation_ids_in_order,
+            )
 
             for idx, inv_id in enumerate(invocation_ids_in_order):
                 segment_content = "".join(main_agent_segments[inv_id])
@@ -1822,23 +1785,12 @@ class AgentService:
         # Publish main agent completion
         _publish(
             "agent_complete",
-            WSAgentCompleteMessage(
-                type="agent_complete",
-                agent_type="main",
-                invocation_id=main_invocation_id,
-                agent_name="Assistant",
-            ).model_dump(mode="json"),
-        )
-
-        # Publish final complete event
-        _publish(
-            "complete",
-            WSCompleteMessage(
-                type="complete",
-                session_id=session_id,
-                message_id=assistant_msg.id if assistant_msg else None,
-                token_usage=token_accumulator.to_dict(),
-            ).model_dump(mode="json"),
+            {
+                "type": "agent_complete",
+                "agent_type": "main",
+                "invocation_id": main_invocation_id,
+                "agent_name": "Assistant",
+            },
         )
 
         # Publish execution status so frontend clears activeExecutionIdRef
@@ -1850,6 +1802,17 @@ class AgentService:
                 "status": "completed",
                 "session_id": str(session_id),
             },
+        )
+
+        # Publish final complete event
+        _publish(
+            "complete",
+            WSCompleteMessage(
+                type="complete",
+                session_id=session_id,
+                message_id=assistant_msg.id if assistant_msg else None,
+                token_usage=token_accumulator.to_dict(),
+            ).model_dump(mode="json"),
         )
 
         # Log summary
@@ -2010,15 +1973,6 @@ class AgentService:
                     except Exception:
                         pass
 
-                # Publish error event
-                event_bus.publish(
-                    AgentEvent(
-                        event_type="error",
-                        data={"message": str(e), "code": 500},
-                        timestamp=datetime.now(),
-                    )
-                )
-
                 # Publish execution status so frontend clears activeExecutionIdRef
                 event_bus.publish(
                     AgentEvent(
@@ -2029,6 +1983,15 @@ class AgentService:
                             "status": "error",
                             "session_id": str(session_id),
                         },
+                        timestamp=datetime.now(),
+                    )
+                )
+
+                # Publish error event
+                event_bus.publish(
+                    AgentEvent(
+                        event_type="error",
+                        data={"message": str(e), "code": 500},
                         timestamp=datetime.now(),
                     )
                 )

--- a/backend/app/ai/config.py
+++ b/backend/app/ai/config.py
@@ -1,15 +1,23 @@
 """Configuration dataclasses for AI agent creation."""
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
+
+
+class OrchestratorMode(StrEnum):
+    """Available agent orchestration strategies."""
+
+    SUPERVISOR = "supervisor"
+    DEEP = "deep"
 
 
 @dataclass(frozen=True)
 class AgentConfig:
-    """Configuration for creating a Deep Agent via DeepAgentOrchestrator.
+    """Configuration for creating an agent graph.
 
-    Encapsulates the parameters passed to ``create_agent`` so callers build
-    a single config object instead of passing many keyword arguments.
+    Encapsulates the parameters passed to orchestrator ``create_*`` methods
+    so callers build a single config object instead of many keyword arguments.
 
     Attributes:
         allowed_tools: Optional list of tool names to include (filters all tools).
@@ -26,7 +34,6 @@ class AgentConfig:
     context_schema: type | None = None
     assistant_role: str | None = None
     user_role: str | None = None
-    use_supervisor: bool = False
 
 
-__all__ = ["AgentConfig"]
+__all__ = ["AgentConfig", "OrchestratorMode"]

--- a/backend/app/ai/deep_agent_orchestrator.py
+++ b/backend/app/ai/deep_agent_orchestrator.py
@@ -16,15 +16,13 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.tools import BaseTool
 
 from app.ai.config import AgentConfig
-from app.ai.middleware.backcast_security import BackcastSecurityMiddleware
-from app.ai.middleware.temporal_context import TemporalContextMiddleware
-from app.ai.subagent_compiler import DEFAULT_SYSTEM_PROMPT, compile_subagents
-from app.ai.subagents import get_all_subagents
-from app.ai.tools import (
-    create_project_tools,
-    filter_tools_by_execution_mode,
-    filter_tools_by_role,
+from app.ai.subagent_compiler import (
+    DEFAULT_SYSTEM_PROMPT,
+    build_backcast_middleware,
+    compile_subagents,
+    filter_tools_for_context,
 )
+from app.ai.subagents import get_all_subagents
 from app.ai.tools.subagent_task import TASK_SYSTEM_PROMPT, build_task_tool
 from app.ai.tools.types import ToolContext
 
@@ -72,136 +70,47 @@ class DeepAgentOrchestrator:
     def create_agent(self, config: AgentConfig | None = None) -> Any:
         """Create a LangChain agent with Backcast tools and context.
 
-        Routing priority:
-        1. ``config.use_supervisor`` -> :class:`SupervisorOrchestrator`
-        2. Default -> traditional subagent-as-tool graph
-
         Args:
             config: Optional AgentConfig encapsulating creation parameters.
-                When None, defaults are used (no tool whitelist, no subagent
-                overrides, no checkpointer, no context schema, no role filtering).
 
         Returns:
             Compiled agent graph (CompiledStateGraph)
-
-        Example:
-            >>> config = AgentConfig(checkpointer=shared_checkpointer)
-            >>> orchestrator = DeepAgentOrchestrator("openai:gpt-4o", context)
-            >>> agent = orchestrator.create_agent(config)
-            >>> result = await agent.ainvoke({"messages": [("user", "Hello")]})
         """
         if config is None:
             config = AgentConfig()
 
-        # Delegate to supervisor orchestrator when flag is set
-        if config.use_supervisor:
-            from app.ai.supervisor_orchestrator import SupervisorOrchestrator
-
-            supervisor = SupervisorOrchestrator(
-                model=self.model,
-                context=self.context,
-                system_prompt=self.system_prompt,
-            )
-            return supervisor.create_supervisor_graph(config)
-
-        allowed_tools = config.allowed_tools
-        subagents = config.subagents
-        checkpointer = config.checkpointer
-        context_schema = config.context_schema
-        assistant_role = config.assistant_role
-        user_role = config.user_role
-        # Log agent creation start
         logger.info(
-            f"[AGENT_CREATION_START] create_agent | "
-            f"model={self.model} | "
-            f"enable_subagents={self.enable_subagents} | "
-            f"system_prompt_length={len(self.system_prompt) if self.system_prompt else 0} | "
-            f"user_role={self.context.user_role} | "
-            f"execution_mode={self.context.execution_mode.value}"
+            "[AGENT_CREATION_START] create_agent | "
+            "model=%s | enable_subagents=%s | execution_mode=%s",
+            self.model,
+            self.enable_subagents,
+            self.context.execution_mode.value,
         )
 
-        # Get existing tools from @ai_tool ecosystem
-        all_tools = create_project_tools(self.context)
+        all_tools = filter_tools_for_context(self.context, config)
 
-        # Filter by allowed_tools if specified
-        if allowed_tools is not None:
-            all_tools = [t for t in all_tools if t.name in allowed_tools]
+        backcast_middleware = build_backcast_middleware(self.context, all_tools)
 
-        # Log tool filtering
-        original_tool_count = len(all_tools)
-        # Filter by execution mode - this prevents LLM from seeing tools it can't use
-        all_tools = filter_tools_by_execution_mode(
-            all_tools, self.context.execution_mode
-        )
-        filtered_tool_count = len(all_tools)
-        logger.info(
-            f"[TOOL_FILTERING] create_agent | "
-            f"execution_mode={self.context.execution_mode.value} | "
-            f"original_tool_count={original_tool_count} | "
-            f"filtered_tool_count={filtered_tool_count} | "
-            f"removed_count={original_tool_count - filtered_tool_count}"
-        )
-
-        # Filter by assistant RBAC role if specified
-        if assistant_role is not None:
-            pre_role_count = len(all_tools)
-            all_tools = filter_tools_by_role(all_tools, assistant_role)
-            logger.info(
-                f"[TOOL_ROLE_FILTERING] create_agent | "
-                f"assistant_role={assistant_role} | "
-                f"pre_filter_count={pre_role_count} | "
-                f"post_filter_count={len(all_tools)} | "
-                f"removed_count={pre_role_count - len(all_tools)}"
-            )
-
-        # Filter by user's actual role (per-user restriction)
-        if user_role is not None:
-            pre_user_count = len(all_tools)
-            all_tools = filter_tools_by_role(all_tools, user_role)
-            logger.info(
-                f"[TOOL_USER_ROLE_FILTERING] create_agent | "
-                f"user_role={user_role} | "
-                f"pre_filter_count={pre_user_count} | "
-                f"post_filter_count={len(all_tools)} | "
-                f"removed_count={pre_user_count - len(all_tools)}"
-            )
-
-        # Build Backcast middleware stack (shared between main agent and subagents)
-        backcast_middleware = [
-            TemporalContextMiddleware(self.context),
-            BackcastSecurityMiddleware(
-                self.context,
-                tools=all_tools,
-                interrupt_node=None,  # Per-request InterruptNode set via ContextVar at invocation time
-            ),
-        ]
-
-        # Build system prompt
         base_prompt = self.system_prompt or DEFAULT_SYSTEM_PROMPT
 
-        # Track compiled subagents (built once, reused for prompt + task tool + logging)
         compiled_subagents: list[dict[str, Any]] | None = None
 
         if self.enable_subagents:
-            # Build subagent compiled graphs — SINGLE compilation
             subagent_configs = (
-                subagents if subagents is not None else get_all_subagents()
+                config.subagents if config.subagents is not None else get_all_subagents()
             )
             compiled_subagents = compile_subagents(
                 self.model,
                 self.context,
                 subagent_configs,
                 all_tools,
-                allowed_tools=allowed_tools,
+                allowed_tools=config.allowed_tools,
             )
 
             if compiled_subagents:
-                # Build prompt suffix from already-compiled dicts (no recompilation)
                 subagent_prompt_suffix = self._build_system_prompt_suffix(
                     compiled_subagents
                 )
-                # Main agent delegates via task tool, but also gets get_temporal_context
-                # for direct access to temporal context information (LOW risk, read-only)
                 task_tool = build_task_tool(compiled_subagents)
                 temporal_context_tool = next(
                     (t for t in all_tools if t.name == "get_temporal_context"), None
@@ -219,7 +128,6 @@ class DeepAgentOrchestrator:
                     f"{len(compiled_subagents)} subagents compiled"
                 )
             else:
-                # Fallback: no valid subagents, use direct tools mode
                 tools = all_tools
                 final_system_prompt = base_prompt
                 middleware = list(backcast_middleware)
@@ -228,7 +136,6 @@ class DeepAgentOrchestrator:
                     "falling back to direct tools mode"
                 )
         else:
-            # Without subagents, main agent needs direct tool access
             tools = all_tools
             final_system_prompt = base_prompt
             middleware = list(backcast_middleware)
@@ -240,23 +147,23 @@ class DeepAgentOrchestrator:
             tools=tools,
             system_prompt=final_system_prompt,
             middleware=middleware,  # type: ignore[arg-type]
-            checkpointer=checkpointer,
-            context_schema=context_schema,
+            checkpointer=config.checkpointer,
+            context_schema=config.context_schema,
         )
 
-        # DEBUG: Log what the main agent has access to (uses already-compiled dicts)
         if logger.isEnabledFor(20):  # INFO level
             logger.info(
-                f"DEBUG: Main agent created with {len(tools)} tools, "
-                f"enable_subagents={self.enable_subagents}"
+                "Main agent created with %d tools, enable_subagents=%s",
+                len(tools),
+                self.enable_subagents,
             )
             if compiled_subagents:
-                logger.info(
-                    f"DEBUG: Created {len(compiled_subagents)} subagents with tools:"
-                )
                 for sa in compiled_subagents:
-                    sa_tools = sa.get("tools", [])
-                    logger.info(f"DEBUG:   - {sa.get('name')}: {len(sa_tools)} tools")
+                    logger.info(
+                        "  - %s: %d tools",
+                        sa.get("name"),
+                        len(sa.get("tools", [])),
+                    )
 
         logger.info("Agent created successfully")
         return agent

--- a/backend/app/ai/execution/agent_event_bus.py
+++ b/backend/app/ai/execution/agent_event_bus.py
@@ -140,10 +140,6 @@ class AgentEventBus:
 
         self._log.append(published)
 
-        # Mark the bus as completed when a terminal event is published.
-        if published.event_type in ("complete", "error"):
-            self._completed = True
-
         dead_queues: list[asyncio.Queue[AgentEvent]] = []
         for queue in self._subscribers:
             try:
@@ -160,6 +156,18 @@ class AgentEventBus:
 
         for queue in dead_queues:
             self._subscribers.discard(queue)
+
+        # Mark the bus as completed AFTER delivering to subscriber queues.
+        # This prevents the race condition where the consumer checks is_completed
+        # and exits before the terminal event is delivered to its queue.
+        if published.event_type in ("complete", "error"):
+            logger.debug(
+                "Bus %s marking completed after delivering %s to %d subscribers",
+                self._execution_id,
+                published.event_type,
+                len(self._subscribers) + len(dead_queues),
+            )
+            self._completed = True
 
         return published
 

--- a/backend/app/ai/subagent_compiler.py
+++ b/backend/app/ai/subagent_compiler.py
@@ -12,8 +12,14 @@ from langchain.agents import create_agent as langchain_create_agent
 from langchain_core.language_models import BaseChatModel
 from langchain_core.tools import BaseTool
 
+from app.ai.config import AgentConfig
 from app.ai.middleware.backcast_security import BackcastSecurityMiddleware
 from app.ai.middleware.temporal_context import TemporalContextMiddleware
+from app.ai.tools import (
+    create_project_tools,
+    filter_tools_by_execution_mode,
+    filter_tools_by_role,
+)
 from app.ai.tools.types import ToolContext
 
 logger = logging.getLogger(__name__)
@@ -36,6 +42,57 @@ When using tools:
 - For status filters, use three-letter codes like 'ACT', 'PLN', 'CLS'
 - Use search to find projects by code or name
 """
+
+
+def filter_tools_for_context(
+    context: ToolContext,
+    config: AgentConfig,
+) -> list[BaseTool]:
+    """Create project tools and apply execution-mode + RBAC filtering.
+
+    Centralizes the identical tool-filtering pipeline shared by both
+    orchestrators.
+
+    Args:
+        context: ToolContext with user permissions and temporal parameters.
+        config: AgentConfig with optional role and allowed_tools filters.
+
+    Returns:
+        Filtered list of tools available for the current request.
+    """
+    all_tools = create_project_tools(context)
+
+    if config.allowed_tools is not None:
+        all_tools = [t for t in all_tools if t.name in config.allowed_tools]
+
+    all_tools = filter_tools_by_execution_mode(all_tools, context.execution_mode)
+
+    if config.assistant_role is not None:
+        all_tools = filter_tools_by_role(all_tools, config.assistant_role)
+
+    if config.user_role is not None:
+        all_tools = filter_tools_by_role(all_tools, config.user_role)
+
+    return all_tools
+
+
+def build_backcast_middleware(
+    context: ToolContext,
+    tools: list[BaseTool],
+) -> list[Any]:
+    """Build the standard Backcast middleware stack.
+
+    Returns:
+        List with TemporalContextMiddleware and BackcastSecurityMiddleware.
+    """
+    return [
+        TemporalContextMiddleware(context),
+        BackcastSecurityMiddleware(
+            context,
+            tools=tools,
+            interrupt_node=None,
+        ),
+    ]
 
 
 def compile_subagents(
@@ -64,7 +121,7 @@ def compile_subagents(
 
     Returns:
         List of dicts with keys: name, description, runnable,
-        structured_output_schema, tools.
+            structured_output_schema, tools.
     """
     results: list[dict[str, Any]] = []
 
@@ -99,14 +156,7 @@ def compile_subagents(
             continue
 
         # Fresh middleware per subagent to avoid mutable state leakage
-        middleware = [
-            TemporalContextMiddleware(context),
-            BackcastSecurityMiddleware(
-                context,
-                tools=subagent_tools,
-                interrupt_node=None,
-            ),
-        ]
+        middleware = build_backcast_middleware(context, subagent_tools)
 
         runnable = langchain_create_agent(
             model=model,

--- a/backend/app/ai/supervisor_orchestrator.py
+++ b/backend/app/ai/supervisor_orchestrator.py
@@ -21,7 +21,7 @@ from langchain.agents import create_agent as langchain_create_agent
 from langchain.agents.middleware.types import AgentState
 from langchain.tools import tool as lc_tool
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph.graph import END, START, StateGraph
 from langgraph.prebuilt.tool_node import InjectedState
@@ -35,16 +35,13 @@ from app.ai.briefing_compiler import (
 )
 from app.ai.config import AgentConfig
 from app.ai.handoff_tools import create_all_handoff_tools
-from app.ai.middleware.backcast_security import BackcastSecurityMiddleware
-from app.ai.middleware.temporal_context import TemporalContextMiddleware
-from app.ai.subagent_compiler import DEFAULT_SYSTEM_PROMPT, compile_subagents
+from app.ai.subagent_compiler import (
+    build_backcast_middleware,
+    compile_subagents,
+    filter_tools_for_context,
+)
 from app.ai.subagents import get_all_subagents
 from app.ai.supervisor_state import BackcastSupervisorState
-from app.ai.tools import (
-    create_project_tools,
-    filter_tools_by_execution_mode,
-    filter_tools_by_role,
-)
 from app.ai.tools.types import ToolContext
 
 logger = logging.getLogger(__name__)
@@ -54,10 +51,12 @@ BRIEFING_ROOM_SUPERVISOR_PROMPT = """You are a supervisor in the Briefing Room f
 You coordinate specialist agents who analyze data and report back through a compiled briefing document.
 
 ## How It Works
-1. Use the `get_briefing` tool to read the current compiled findings from all specialists
-2. Based on the briefing, decide which specialist to hand off to next
-3. After each specialist contributes, review the updated briefing
-4. When you have enough information, synthesize the findings into a response
+The current briefing is injected into your context as a system message before every turn.
+Review it FIRST — it already contains all specialist findings so far.
+1. Read the injected briefing to see what's already been analyzed
+2. If the user's request is already answered in the briefing, respond directly
+3. If not, hand off to the most relevant specialist
+4. After a specialist contributes, the briefing is updated automatically
 
 ## Available Specialists
 - project_manager -> Project CRUD, WBEs, cost elements, cost tracking, progress entries
@@ -69,55 +68,65 @@ You coordinate specialist agents who analyze data and report back through a comp
 - general_purpose -> Unclear or cross-cutting requests
 
 ## Guidelines
-- Always call get_briefing first to see what's already been analyzed
-- CRITICAL: Before handing off to a specialist, check if the briefing already
-  contains findings that address the user's request. If the task is complete,
-  respond directly instead of handing off again.
+- The briefing is already in your context — read it before deciding anything
+- If findings already address the user's request, respond directly. Do NOT hand off again.
 - Do NOT hand off to the same specialist more than once for the same task.
 - Hand off to the most relevant specialist for each aspect of the request
 - After receiving specialist findings, synthesize a clear, concise response
 - Do NOT repeat detailed findings -- highlight key insights and actionable information
 
-## Guidelines for Follow-up Questions
-- When the briefing contains existing findings from previous questions, check if
-  the current question is already answered in those findings
-- Previous specialist findings remain valid unless contradicted by new context
-- Prefer reusing existing analysis over re-invoking specialists
-- The briefing accumulates across the entire conversation - use it!
-
 ## CRITICAL COMPLETION RULES
 1. Maximum 2 specialist cycles for simple requests. Do NOT over-delegate.
-2. Always call get_briefing before deciding to hand off -- check what's already there.
+2. Always check the injected briefing before deciding to hand off.
 3. If a specialist has completed the requested work, acknowledge completion and summarize.
-
-## MANDATORY PRE-HANDOFF CHECKLIST
-Before calling ANY handoff_to_X tool, you MUST:
-1. Call get_briefing and check the current findings
-2. Check Specialist Contributions section -- if specialist X already has findings, DO NOT handoff to X again
-3. Verify the user's request hasn't already been addressed
-
-Failure to check will result in redundant work, wasted API costs, and poor user experience.
 """
 
 _BRIEFING_HANDOFF_SUFFIX = """
 IMPORTANT: You do NOT have direct access to Backcast tools.
 ALL Backcast operations must be delegated to specialists via handoff tools.
 
-Always start by calling get_briefing to review the current state of knowledge.
+The current briefing is already in your context — review it before deciding.
+You can call get_briefing if you need to refresh after a specialist returns.
 """
 
 _SCOPE_BOUNDARY = (
     "\n\n## SCOPE BOUNDARY\n"
     "Focus ONLY on tasks within your specialist domain. "
     "Do NOT perform work that belongs to another specialist.\n\n"
-    "## OUTPUT FORMAT\n"
-    "At the end of your response, include these sections if applicable:\n"
+    "## OUTPUT FORMAT (MANDATORY)\n"
+    "After completing all tool calls, you MUST write a final response that summarizes "
+    "your analysis and conclusions in plain text. Do NOT leave your response empty.\n\n"
+    "Include these sections:\n"
     "- **## Key Findings**: Bullet list of your most important discoveries\n"
     "- **## Open Questions**: Questions that need answers from other specialists or the user\n"
     "- **## Delegation Notes**: Context for any specialist who should continue this work "
     "(include relevant IDs, names, partial results)\n\n"
     "These sections help the supervisor coordinate follow-up work."
 )
+
+_BRIEFING_CONTEXT_PREFIX = (
+    "## Current Briefing\n"
+    "Below is the compiled briefing with all specialist findings so far. "
+    "Review this BEFORE deciding whether to delegate work or respond directly.\n\n"
+)
+
+
+def _briefing_update(doc: BriefingDocument) -> dict[str, Any]:
+    """Build the standard state update after briefing initialization.
+
+    Injects the current briefing as a SystemMessage so the supervisor
+    always sees specialist findings before deciding what to do.
+    """
+    briefing_md = doc.to_markdown() if doc.sections else "No findings yet."
+    return {
+        "briefing_data": doc.model_dump(),
+        "supervisor_iterations": 0,
+        "max_supervisor_iterations": 3,
+        "completed_specialists": set(),
+        "messages": [
+            SystemMessage(content=f"{_BRIEFING_CONTEXT_PREFIX}{briefing_md}")
+        ],
+    }
 
 
 class _BriefingSupervisorState(AgentState[Any]):
@@ -203,19 +212,7 @@ class SupervisorOrchestrator:
         )
 
         # --- 1. Tool filtering ---
-        all_tools = create_project_tools(self.context)
-        if config.allowed_tools is not None:
-            all_tools = [t for t in all_tools if t.name in config.allowed_tools]
-
-        all_tools = filter_tools_by_execution_mode(
-            all_tools, self.context.execution_mode
-        )
-
-        if config.assistant_role is not None:
-            all_tools = filter_tools_by_role(all_tools, config.assistant_role)
-
-        if config.user_role is not None:
-            all_tools = filter_tools_by_role(all_tools, config.user_role)
+        all_tools = filter_tools_for_context(self.context, config)
 
         # --- 2. Compile specialists ---
         subagent_configs = (
@@ -266,15 +263,11 @@ class SupervisorOrchestrator:
         )
 
         # --- 5. Create specialist wrapper nodes ---
-        configs_by_name = {cfg["name"]: cfg for cfg in subagent_configs}
         specialist_wrappers: dict[str, Any] = {}
         for sg in specialist_graphs:
-            cfg = configs_by_name.get(sg["name"], {})
-            subagent_prompt = cfg.get("system_prompt", DEFAULT_SYSTEM_PROMPT)
             specialist_wrappers[sg["name"]] = self._create_specialist_wrapper(
                 specialist_name=sg["name"],
                 specialist_graph=sg["runnable"],
-                specialist_system_prompt=subagent_prompt,
             )
 
         # --- 6. Build the initialize_briefing node ---
@@ -299,34 +292,21 @@ class SupervisorOrchestrator:
                 # Reuse existing briefing, update request to current question
                 try:
                     doc = BriefingDocument.model_validate(existing_briefing)
-                    # Update original_request to the current/follow-up question
                     doc.original_request = user_request
-                    # Keep all accumulated sections and task_history
                     logger.info(
                         "[SUPERVISOR] Reusing existing briefing with %d sections",
                         len(doc.sections),
                     )
-                    return {
-                        "briefing_data": doc.model_dump(),
-                        "supervisor_iterations": 0,
-                        "max_supervisor_iterations": 3,
-                        "completed_specialists": set(),  # Reset for new question
-                    }
+                    return _briefing_update(doc)
                 except Exception:
                     logger.debug(
                         "[SUPERVISOR] Failed to validate existing briefing, creating new one"
                     )
-                    pass  # Fall through to new briefing
 
             # Create new briefing (first message or recovery)
             briefing_data = initialize_briefing(user_request)
-
-            return {
-                "briefing_data": briefing_data,
-                "supervisor_iterations": 0,
-                "max_supervisor_iterations": 3,
-                "completed_specialists": set(),
-            }
+            doc = BriefingDocument.model_validate(briefing_data)
+            return _briefing_update(doc)
 
         # --- 7. Build parent graph ---
         parent = StateGraph(BackcastSupervisorState)
@@ -415,7 +395,6 @@ class SupervisorOrchestrator:
         self,
         specialist_name: str,
         specialist_graph: Any,
-        specialist_system_prompt: str,
     ) -> Any:
         """Create a briefing-specialist wrapper node for a compiled agent.
 
@@ -424,10 +403,12 @@ class SupervisorOrchestrator:
         invokes the specialist graph, then compiles findings back into the
         briefing document.
 
+        The specialist's system prompt is baked into its compiled graph by
+        ``compile_subagents`` — the wrapper only provides runtime context.
+
         Args:
             specialist_name: Human-readable name for logging and briefing sections.
             specialist_graph: Compiled LangGraph (output of compile_subagents()).
-            specialist_system_prompt: System prompt for the specialist agent.
 
         Returns:
             Async function suitable as a LangGraph node.
@@ -445,39 +426,31 @@ class SupervisorOrchestrator:
                 return Command(
                     update={
                         "active_agent": "supervisor",
-                        "supervisor_iterations": 1,
+                        "supervisor_iterations": state.get("supervisor_iterations", 0) + 1,
                     },
                     goto=END,
                 )
 
             briefing_markdown = ""
+            task_desc = "Execute specialist task from briefing"
+            rationale: str | None = None
             briefing_data_raw = state.get("briefing_data", {})
             if briefing_data_raw:
                 try:
-                    briefing_markdown = BriefingDocument.model_validate(
-                        briefing_data_raw
-                    ).to_markdown()
+                    doc = BriefingDocument.model_validate(briefing_data_raw)
+                    briefing_markdown = doc.to_markdown()
+                    if doc.task_history:
+                        latest = doc.task_history[-1]
+                        task_desc = latest.description
+                        rationale = latest.rationale
                 except Exception:
-                    briefing_markdown = ""
-
-            # Extract the current task assignment for this specialist
-            task_desc = "Execute specialist task from briefing"
-            rationale: str | None = None
-            try:
-                doc = BriefingDocument.model_validate(state.get("briefing_data", {}))
-                if doc.task_history:
-                    latest = doc.task_history[-1]
-                    task_desc = latest.description
-                    rationale = latest.rationale
-            except Exception:
-                pass
+                    pass
 
             assignment_block = f"## Your Assignment\n\n{task_desc}"
             if rationale:
                 assignment_block += f"\n\n**Supervisor's rationale:** {rationale}"
 
             isolated_messages = [
-                SystemMessage(content=specialist_system_prompt),
                 HumanMessage(
                     content=(
                         f"{assignment_block}\n\n## Briefing\n\n"
@@ -516,17 +489,40 @@ class SupervisorOrchestrator:
                     update={
                         "briefing_data": updated_data,
                         "active_agent": "supervisor",
-                        "supervisor_iterations": 1,
+                        "supervisor_iterations": state.get("supervisor_iterations", 0) + 1,
+                        "tool_call_count": 0,
                         "completed_specialists": {specialist_name},
                     },
                     goto="supervisor",
                 )
 
+            # Extract specialist findings: prefer the last AI response with
+            # actual content.  Models like DeepSeek sometimes return an empty
+            # final AIMessage after tool execution, so we fall back through
+            # earlier messages and finally to tool results.
             findings = ""
-            for msg in reversed(result.get("messages", [])):
+            messages = result.get("messages", [])
+            for msg in reversed(messages):
                 if isinstance(msg, AIMessage) and not msg.tool_calls:
-                    findings = str(msg.content)
-                    break
+                    content = str(msg.content).strip()
+                    if content:
+                        findings = content
+                        break
+
+            if not findings:
+                # Fallback: concatenate tool results as the specialist's findings
+                tool_parts: list[str] = []
+                for msg in reversed(messages):
+                    if isinstance(msg, ToolMessage) and msg.content:
+                        tool_parts.append(str(msg.content))
+                if tool_parts:
+                    findings = "\n\n".join(reversed(tool_parts))
+                    logger.info(
+                        "[SPECIALIST_FINDINGS] Specialist %s: empty AI response, "
+                        "fell back to %d tool results",
+                        specialist_name,
+                        len(tool_parts),
+                    )
 
             parsed = parse_structured_findings(findings)
 
@@ -552,7 +548,7 @@ class SupervisorOrchestrator:
                     "briefing_data": updated_data,
                     "active_agent": "supervisor",
                     "tool_call_count": result.get("tool_call_count", 0),
-                    "supervisor_iterations": 1,
+                    "supervisor_iterations": state.get("supervisor_iterations", 0) + 1,
                     "completed_specialists": {specialist_name},
                 },
                 goto="supervisor",
@@ -562,14 +558,7 @@ class SupervisorOrchestrator:
 
     def _build_middleware(self, tools: list[BaseTool]) -> list[Any]:
         """Build the middleware stack for the supervisor agent."""
-        return [
-            TemporalContextMiddleware(self.context),
-            BackcastSecurityMiddleware(
-                self.context,
-                tools=tools,
-                interrupt_node=None,
-            ),
-        ]
+        return build_backcast_middleware(self.context, tools)
 
     def _build_fallback_graph(
         self,

--- a/backend/app/api/routes/ai_chat.py
+++ b/backend/app/api/routes/ai_chat.py
@@ -55,6 +55,60 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/ai/chat", tags=["AI Chat"])
 
 
+async def forward_bus_events(
+    bus: AgentEventBus,
+    websocket: WebSocket,
+    user_id: UUID | None = None,
+) -> None:
+    """Forward events from an AgentEventBus to a WebSocket connection.
+
+    Subscribes to the bus, loops with 1-second timeout to check disconnects,
+    and forwards each event as JSON. Unsubscribes on exit.
+    """
+    queue = bus.subscribe()
+    try:
+        while not bus.is_completed:
+            try:
+                event = await asyncio.wait_for(queue.get(), timeout=1.0)
+            except TimeoutError:
+                if not is_websocket_connected(websocket):
+                    break
+                continue
+            if not is_websocket_connected(websocket):
+                break
+            payload = {**event.data, "type": event.event_type}
+            try:
+                await websocket.send_json(payload)
+            except Exception:
+                if user_id:
+                    logger.warning(
+                        "Failed to forward event to WebSocket for user %s", user_id
+                    )
+                break
+            if event.event_type in ("complete", "error"):
+                break
+        else:
+            # Loop exited because bus.is_completed became True.
+            # Drain any remaining events from the queue (especially the complete/error event).
+            logger.debug(
+                "forward_bus_events: bus completed, draining queue for bus %s",
+                bus.execution_id,
+            )
+            while not queue.empty():
+                try:
+                    event = queue.get_nowait()
+                    if not is_websocket_connected(websocket):
+                        break
+                    payload = {**event.data, "type": event.event_type}
+                    await websocket.send_json(payload)
+                    if event.event_type in ("complete", "error"):
+                        break
+                except Exception:
+                    break
+    finally:
+        bus.unsubscribe(queue)
+
+
 def _enrich_session_briefing(
     session_public: AIConversationSessionPublic,
     session: AIConversationSession,
@@ -642,26 +696,7 @@ async def chat_stream(
                             continue
 
                         # Subscribe to live events
-                        sub_queue = bus.subscribe()
-                        try:
-                            while not bus.is_completed:
-                                try:
-                                    event = await asyncio.wait_for(
-                                        sub_queue.get(),
-                                        timeout=1.0,
-                                    )
-                                    if not is_websocket_connected(websocket):
-                                        break
-                                    payload = {**event.data, "type": event.event_type}
-                                    await websocket.send_json(payload)
-                                    if event.event_type in ("complete", "error"):
-                                        break
-                                except TimeoutError:
-                                    if not is_websocket_connected(websocket):
-                                        break
-                                    continue
-                        finally:
-                            bus.unsubscribe(sub_queue)
+                        await forward_bus_events(bus, websocket, user_id=user_id)
                     except Exception as sub_err:
                         logger.error(
                             f"Error in subscribe handler for user {user_id}: {sub_err}",
@@ -875,36 +910,7 @@ async def chat_stream(
                     uid: UUID,
                 ) -> asyncio.Task[None]:
                     """Create a background task that forwards bus events to the WebSocket."""
-
-                    async def _forward() -> None:
-                        queue = bus.subscribe()
-                        try:
-                            while True:
-                                try:
-                                    event = await asyncio.wait_for(
-                                        queue.get(),
-                                        timeout=1.0,
-                                    )
-                                except TimeoutError:
-                                    if not is_websocket_connected(ws):
-                                        break
-                                    continue
-                                if not is_websocket_connected(ws):
-                                    break
-                                payload = {**event.data, "type": event.event_type}
-                                try:
-                                    await ws.send_json(payload)
-                                except Exception:
-                                    logger.warning(
-                                        f"Failed to forward event to WebSocket for user {uid}"
-                                    )
-                                    break
-                                if event.event_type in ("complete", "error"):
-                                    break
-                        finally:
-                            bus.unsubscribe(queue)
-
-                    return asyncio.create_task(_forward())
+                    return asyncio.create_task(forward_bus_events(bus, ws, user_id=uid))
 
                 execution_task = create_execution_task(
                     msg=request.message,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
     AI_TOKEN_BUFFER_MAX_SIZE: int = 10000  # Max tokens before forced flush
 
     # AI Agent Orchestration
-    AI_ORCHESTRATOR: str = "supervisor"  # "supervisor" | "deep"
+    AI_ORCHESTRATOR: str = "supervisor"  # OrchestratorMode value
 
     # AI Approval Settings (used by BackcastSecurityMiddleware polling loop)
     AI_APPROVAL_TIMEOUT_SECONDS: float = 60.0

--- a/backend/app/services/evm_service.py
+++ b/backend/app/services/evm_service.py
@@ -1762,7 +1762,8 @@ class EVMService:
             granularity: Time granularity (day, week, month)
 
         Returns:
-            List of datetime points at the specified granularity
+            List of datetime points at the specified granularity.
+            The end_date is always included as the last point.
         """
         dates: list[datetime] = []
         current_date = start_date
@@ -1793,6 +1794,10 @@ class EVMService:
                     current_date = current_date.replace(
                         month=current_date.month + 1, day=1
                     )
+
+        # Ensure end_date is always included as the last point
+        if dates and dates[-1] != end_date:
+            dates.append(end_date)
 
         return dates
 

--- a/backend/tests/unit/services/test_evm_timeseries.py
+++ b/backend/tests/unit/services/test_evm_timeseries.py
@@ -105,10 +105,11 @@ class TestEVMTimeSeriesDateRangeHelper:
         )
 
         # Assert
-        assert len(dates) == 3  # Jan 1, Feb 1, Mar 1
+        assert len(dates) == 4  # Jan 1, Feb 1, Mar 1, Mar 31 (end_date always included)
         assert dates[0] == datetime(2024, 1, 1)
         assert dates[1] == datetime(2024, 2, 1)
         assert dates[2] == datetime(2024, 3, 1)
+        assert dates[3] == datetime(2024, 3, 31)  # end_date appended
 
     def test_generate_date_intervals_monthly_year_boundary(self) -> None:
         """Test monthly date interval generation across year boundary.

--- a/docs/03-project-plan/iterations/2026-05-01-fix-ai-chat-streaming-completion/00-analysis.md
+++ b/docs/03-project-plan/iterations/2026-05-01-fix-ai-chat-streaming-completion/00-analysis.md
@@ -1,0 +1,483 @@
+# Analysis: Fix Frontend AI Chat Streaming Completion Issues
+
+**Created:** 2026-05-01
+**Request:** Fix the frontend AI chat streaming state that never transitions to "complete", preventing follow-up messages and requiring page refresh.
+
+---
+
+## Clarified Requirements
+
+### Functional Requirements
+
+- **FR-1**: The frontend must transition `isStreaming` to `false` when the backend sends the "complete" WebSocket event
+- **FR-2**: The textarea must re-enable and the stop button must disappear after streaming completes
+- **FR-3**: Users must be able to send follow-up messages without refreshing the page
+- **FR-4**: Multi-turn conversations must work (e.g., "create a project" then "move it to active status")
+- **FR-5**: The WebSocket connection must remain open after completion for follow-up messages
+
+### Non-Functional Requirements
+
+- **NFR-1**: No race conditions between WebSocket events and React state updates
+- **NFR-2**: Minimal change -- surgical fix, no refactoring of working systems
+- **NFR-3**: Fix must work with React 18 Strict Mode (double mount/unmount cycle)
+
+### Constraints
+
+- Branch: `agent-architecture`
+- Frontend: React 18 + TypeScript + Ant Design v6
+- Backend is verified working -- no backend changes needed for core fix
+
+---
+
+## Context Discovery
+
+### Architecture Context
+
+- **Bounded contexts involved**: AI Chat (frontend feature module)
+- **WebSocket protocol**: Simple JSON protocol with discriminated `type` field
+- **Event ordering (backend publishes)**:
+  1. `agent_complete` (agent_type: "main" or "subagent")
+  2. `complete` (session_id, message_id, token_usage)
+  3. `execution_status` (status: "completed")
+- **Forwarding behavior**: `forward_bus_events` breaks the loop after sending "complete" or "error", so `execution_status` is NEVER forwarded to the frontend
+
+### Codebase Analysis
+
+**Backend (verified working):**
+
+- `backend/app/api/routes/ai_chat.py` line 79: `payload = {**event.data, "type": event.event_type}` -- correctly merges event data with type
+- `backend/app/api/routes/ai_chat.py` line 88: Loop breaks after "complete" event -- `execution_status` never forwarded
+- `backend/app/ai/agent_service.py` lines 1790-1810: Publishes `complete` then `execution_status` -- ordering issue
+- `backend/app/ai/execution/agent_event_bus.py`: Event bus correctly publishes to subscriber queues
+
+**Frontend (needs fix):**
+
+- `frontend/src/features/ai/chat/api/useStreamingChat.ts`:
+  - Line 571-581: `isCompleteMessage` handler -- correctly calls `callbacks.onComplete()`, clears `activeExecutionIdRef`, keeps connection alive
+  - Line 1111-1122: `activeExecutionId` effect -- closes WebSocket when `activeExecutionId` becomes null and connection is open
+  - Line 883-1105: Main connection `useEffect` -- manages lifecycle, Strict Mode handling
+
+- `frontend/src/features/ai/chat/components/ChatInterface.tsx`:
+  - Lines 233-241: `isStreaming` computed value -- checks 5 conditions
+  - Lines 472-528: `handleComplete` callback -- sets all streaming flags to idle state
+  - Line 709: `activeExecutionId: currentSession?.active_execution?.id ?? null`
+
+**Key files involved:**
+
+| File | Role |
+|------|------|
+| `frontend/src/features/ai/chat/api/useStreamingChat.ts` | WebSocket hook managing connection and message routing |
+| `frontend/src/features/ai/chat/components/ChatInterface.tsx` | Main chat UI with streaming state management |
+| `frontend/src/features/ai/chat/components/MessageInput.tsx` | Input component that checks `isStreaming` for disabled state |
+| `frontend/src/features/ai/chat/types.ts` | Type guards and WebSocket message type definitions |
+| `backend/app/api/routes/ai_chat.py` | WebSocket endpoint and event forwarding |
+
+---
+
+## Root Cause Analysis
+
+After thorough static analysis of the codebase, I identified **three interacting issues** that can cause the stuck streaming state:
+
+### Issue A: Backend event ordering + forward loop break
+
+The backend publishes events in this order:
+1. `agent_complete`
+2. `complete`
+3. `execution_status` (with `status: "completed"`)
+
+But `forward_bus_events` (line 88) breaks the loop after "complete":
+```python
+if event.event_type in ("complete", "error"):
+    break
+```
+
+This means the `execution_status` event is **never sent to the frontend**. This is not itself the root cause of the stuck state, but it creates a side effect: the backend DB updates `active_execution_id = None` on the session AFTER the "complete" event is sent. When the frontend refetches sessions (triggered by `handleComplete`), it may see the session with `active_execution` still set, then later see it as null.
+
+### Issue B: `activeExecutionId` effect closes WebSocket prematurely
+
+The `useStreamingChat` hook has an effect (lines 1111-1122) that watches `activeExecutionId`:
+
+```javascript
+useEffect(() => {
+  if (activeExecutionId && wsRef.current === null) {
+    connectRef.current?.();
+  } else if (!activeExecutionId && wsRef.current) {
+    wsRef.current.close();
+    wsRef.current = null;
+    setConnectionState(WSConnectionState.CLOSED);
+  }
+}, [activeExecutionId]);
+```
+
+When `handleComplete` invalidates the sessions cache, the session refetch may return data where `active_execution` is now `null`. This causes `activeExecutionId` to transition from a UUID string to `null`. The effect then **closes the WebSocket connection**.
+
+This is actually fine for the current message -- the "complete" event has already been processed. But it means the connection is closed, and the next message will need to reconnect.
+
+However, there is a more subtle race condition: if the sessions refetch returns data with `active_execution` STILL set (because the backend DB hasn't committed yet), and then a SECOND refetch returns `active_execution` as `null`, the effect fires twice -- first doing nothing, then closing the connection. This is the intended behavior.
+
+### Issue C (PRIMARY ROOT CAUSE): `handleComplete` callback dependency staleness
+
+The `handleComplete` callback in `ChatInterface.tsx` (lines 472-528) has `[queryClient]` as its dependency array. The callback is stored in a ref via the callbacks pattern in `useStreamingChat.ts`.
+
+The critical finding: the `handleComplete` callback IS being called (the `isCompleteMessage` type guard passes), and it DOES set `isStreaming` to `false` through its state updates. However, there is a **subtle interaction** between the `.then()` callback in `handleComplete` and the `activeExecutionId` effect.
+
+Here is the sequence that causes the stuck state:
+
+1. Backend sends "complete" event
+2. `handleMessage` calls `callbacks.onComplete()` which calls `handleComplete`
+3. `handleComplete` runs:
+   - Sets `isWaitingForResponse(false)`
+   - Sets `activeToolCalls([])`
+   - Sets all streams to `is_active: false`
+   - Calls `queryClient.invalidateQueries(sessions)` -- triggers async refetch
+   - Calls `queryClient.refetchQueries(messages)` -- returns a Promise
+4. React batches the state updates from step 3 -- `isStreaming` becomes `false`
+5. The sessions refetch completes, returns session with `active_execution: null`
+6. React re-renders with new `activeExecutionId = null`
+7. The `activeExecutionId` effect fires: `!activeExecutionId && wsRef.current` -> closes WebSocket
+8. The WebSocket `close` event handler fires: `setConnectionState(WSConnectionState.CLOSED)`
+9. The main connection `useEffect` cleanup fires because the WebSocket is now closed
+10. **The cleanup sets `isFirstMountRef.current = true`** (line 1084)
+11. The main connection `useEffect` re-runs, and since `isFirstMountRef.current` is now `true`, it creates a NEW WebSocket connection
+12. The new connection triggers `setConnectionState(WSConnectionState.CONNECTING)` then `OPEN`
+
+Wait -- actually, the main connection `useEffect` depends on `[token, assistantId, handleMessage, clearCompleteTimeout]`. These haven't changed, so the effect should NOT re-run just because the WebSocket was closed. The effect only re-runs when its dependencies change.
+
+Let me reconsider. The `activeExecutionId` effect at line 1111 closes the WebSocket directly (not through the cancel function). It sets `wsRef.current = null` and `setConnectionState(WSConnectionState.CLOSED)`. But it does NOT trigger a reconnection. The main connection useEffect at line 883 would only re-run if its dependencies change.
+
+So after the `activeExecutionId` effect closes the connection:
+- `wsRef.current` is `null`
+- `connectionState` is `CLOSED`
+- The main useEffect does NOT re-run (dependencies unchanged)
+
+This means the WebSocket is closed and NOT reconnected. When the user tries to send a follow-up message, `sendMessage` detects `!ws || ws.readyState !== WebSocket.OPEN`, stores the pending message, and calls `connectRef.current?.()`. This should trigger a reconnection and send the pending message.
+
+But here is the key question: **does `connectRef.current` still point to a valid function after the cleanup ran?**
+
+Looking at the cleanup (lines 1081-1103):
+```javascript
+return () => {
+  isFirstMountRef.current = true;
+  cancelledRef.current = true;
+  clearCompleteTimeout();
+  // ... close WebSocket
+};
+```
+
+The cleanup sets `cancelledRef.current = true`. And the `connect` function inside the effect checks:
+```javascript
+if (cancelledRef.current) {
+  return;
+}
+```
+
+But `connectRef.current` stores the `connect` function from the FIRST run of the effect. After the effect cleanup runs, `connectRef.current` still points to the old `connect` function which checks `cancelledRef.current`. Since cleanup set `cancelledRef.current = true`, calling `connectRef.current()` will do nothing because it immediately returns.
+
+**This is the bug.** The `activeExecutionId` effect at line 1111 closes the WebSocket, but does NOT reset `cancelledRef.current`. The main connection useEffect's cleanup sets `cancelledRef.current = true`. But the cleanup does NOT run when the `activeExecutionId` effect closes the connection (the cleanup only runs when the main useEffect's dependencies change or on unmount).
+
+Wait, I need to reconsider. The `activeExecutionId` effect directly closes the WebSocket without going through the main useEffect's cleanup. The main useEffect's cleanup only runs when the effect re-runs (dependencies change) or on component unmount. So `cancelledRef.current` should still be `false` after the `activeExecutionId` effect closes the connection.
+
+Actually, let me re-examine. The `activeExecutionId` effect at line 1111 does:
+```javascript
+wsRef.current.close();
+wsRef.current = null;
+setConnectionState(WSConnectionState.CLOSED);
+```
+
+This directly closes the WebSocket. The main useEffect's cleanup does NOT run (its dependencies haven't changed). So `cancelledRef.current` remains `false`.
+
+When the user sends a follow-up message, `sendMessage` checks:
+```javascript
+if (!ws || ws.readyState !== WebSocket.OPEN) {
+  pendingMessageRef.current = { ... };
+  if (!ws || ws.readyState === WebSocket.CLOSED) {
+    connectRef.current?.();
+  }
+  return;
+}
+```
+
+Since `wsRef.current` is `null` (set to null by the activeExecutionId effect), `connectRef.current?.()` is called. The `connect` function checks `cancelledRef.current` which is `false`, so it should proceed to create a new connection.
+
+But wait -- `isFirstMountRef.current` was set to `true` in the main useEffect's cleanup... No, the cleanup didn't run! The cleanup only runs when the effect re-runs or on unmount.
+
+So `isFirstMountRef.current` is `false` (set to `false` on the first mount at line 897). The `connect` function is defined inside the main useEffect, and it doesn't check `isFirstMountRef`. The `isFirstMountRef` check is only at the top of the main useEffect (line 893).
+
+So `connectRef.current()` should work correctly -- it creates a new WebSocket, and when it opens, sends the pending message. This should work.
+
+**Revised conclusion:** After careful analysis, the lazy reconnection path should work. The bug must be elsewhere.
+
+Let me look at the problem from the user's symptoms again. The user says:
+- "The frontend's React state never transitions out of streaming mode"
+- "Stop button remains visible, textarea stays disabled"
+- "Users must refresh the page"
+
+This means `isStreaming` stays `true`. Let me check all conditions:
+
+1. `streamingState.main.length > 0` -- cleared to "" in handleComplete
+2. `mainStreams.some(ms => ms.is_active)` -- all set to is_active: false in handleComplete
+3. `subagents.some(sa => sa.is_active)` -- all set to is_active: false in handleComplete
+4. `activeToolCalls.length > 0` -- cleared to [] in handleComplete
+5. `isWaitingForResponse` -- set to false in handleComplete
+
+If `handleComplete` is called, ALL conditions become false and `isStreaming` becomes false.
+
+**The only way `isStreaming` stays true is if `handleComplete` is NOT called.**
+
+Let me re-examine why `handleComplete` might not be called:
+
+1. The "complete" WebSocket event is never sent (backend issue) -- but user says backend is verified working
+2. The "complete" event is sent but not received (WebSocket issue) -- possible if connection drops
+3. The "complete" event is received but `isCompleteMessage` returns false -- possible if payload is malformed
+4. The "complete" event is received but `handleMessage` returns early before reaching the `isCompleteMessage` check -- possible if an earlier condition matches
+5. `callbacks.onComplete` is null or stale -- unlikely given the ref pattern
+
+For scenario 4, let me check if any earlier handler could match a "complete" message. Looking at `handleMessage`:
+- `message.type === "execution_started"` -- no
+- `message.type === "execution_status"` -- no
+- `message.type === "ping"` -- no
+- `isApprovalRequestMessage` -- checks `msg.type === "approval_request"` -- no
+- `isTokenBatchMessage` -- checks `message.type === "token_batch"` -- no
+- `isTokenMessage` -- checks `msg.type === "token"` -- no
+- `isSubagentMessage` -- checks `message.type === "subagent"` -- no
+- `isSubagentResultMessage` -- checks `message.type === "subagent_result"` -- no
+- `isAgentCompleteMessage` -- checks `message.type === "agent_complete"` -- no
+- `isToolCallMessage` -- checks `message.type === "tool_call"` -- no
+- `isToolResultMessage` -- checks `message.type === "tool_result"` -- no
+- `isContentResetMessage` -- checks `message.type === "content_reset"` -- no
+- `isBriefingMessage` -- checks `message.type === "briefing_update"` -- no
+- `isThinkingMessage` -- checks `message.type === "thinking"` -- no
+- `isPollingHeartbeatMessage` -- checks `message.type === "polling_heartbeat"` -- no
+- `isCompleteMessage` -- checks `msg.type === "complete" && typeof msg.session_id === "string"` -- YES
+
+None of the earlier handlers should match a "complete" message.
+
+For scenario 3, the payload from the backend is:
+```json
+{"type": "complete", "session_id": "<uuid-string>", "message_id": "<uuid-string>", "token_usage": {...}}
+```
+
+The type guard checks `msg.type === "complete" && typeof msg.session_id === "string"`. This should pass since `session_id` is a UUID serialized to string by Pydantic v2's `model_dump(mode="json")`.
+
+**Wait -- there is a subtle issue.** The `session_id` in the `WSCompleteMessage` is a Pydantic `UUID` field. `model_dump(mode="json")` serializes it as a string. But the `forward_bus_events` function does:
+
+```python
+payload = {**event.data, "type": event.event_type}
+```
+
+`event.data` is the result of `WSCompleteMessage(...).model_dump(mode="json")`. This should include `session_id` as a string. But what if `session_id` is a Python `UUID` object that hasn't been serialized? Let me check.
+
+The `_publish` function at line 1002 creates an `AgentEvent` with `data=<dict>`. The data comes from `WSCompleteMessage(...).model_dump(mode="json")`, which serializes UUIDs to strings. So the dict should have `session_id` as a string.
+
+But then the event is put into an asyncio.Queue, and later retrieved in `forward_bus_events`. The `event.data` should still be the same dict. So `payload` should have `session_id` as a string.
+
+**However**, there is one more thing to check: what about the `message_id` field? The backend code at line 1796:
+
+```python
+message_id=assistant_msg.id if assistant_msg else None,
+```
+
+If `assistant_msg` is `None`, `message_id` is `None`. The `WSCompleteMessage` schema allows `message_id: UUID | None = None`. In `model_dump(mode="json")`, `None` is serialized as `null`. This is fine for the frontend's type guard which only checks `session_id`.
+
+**Final hypothesis:** The issue may be intermittent and related to the WebSocket connection state. If the connection drops during the execution (e.g., due to the `activeExecutionId` effect closing it), the "complete" event may be lost. The reconnection logic would not help because the bus is marked as completed and the loop has broken.
+
+Let me check if there is a timing issue where the `activeExecutionId` effect could close the connection BEFORE the "complete" event arrives.
+
+The flow is:
+1. User sends message -> WebSocket connected, message sent
+2. Backend starts execution -> publishes `execution_status` with `status: "running"`
+3. This event is forwarded to the frontend -> `handleMessage` stores `execution_id` in `activeExecutionIdRef`
+4. But wait -- does this `execution_status` event also trigger a session update? No, `onExecutionStatus` only invalidates the sessions cache. The cache invalidation triggers an async refetch.
+5. The sessions refetch returns the session with `active_execution` set to the new execution
+6. `activeExecutionId` changes from `null` to `"<execution-id>"`
+7. The `activeExecutionId` effect fires: `activeExecutionId && wsRef.current === null` -- but wsRef.current is NOT null (connection is open), so nothing happens
+8. Streaming proceeds...
+9. Backend finishes -> publishes `complete`
+10. `handleComplete` fires -> invalidates sessions cache -> async refetch
+11. Backend publishes `execution_status` with `status: "completed"` -- but forwarding loop already broke
+12. Backend commits `execution.status = "completed"` and `session.active_execution_id = None`
+13. Sessions refetch returns session with `active_execution: null`
+14. `activeExecutionId` changes from `"<execution-id>"` to `null`
+15. The `activeExecutionId` effect fires: `!activeExecutionId && wsRef.current` -- closes WebSocket
+
+But by this point, the "complete" event has already been processed (step 9-10). So this shouldn't cause the stuck state.
+
+**Unless** there is a scenario where step 14 happens BEFORE step 9. This could occur if:
+- The sessions cache is stale and refetches return `active_execution: null` before the backend even starts processing
+- The `onExecutionStatus` callback for the "running" status triggers a sessions refetch that returns `active_execution: null`
+
+This seems unlikely. Let me consider another scenario: what if the user is reconnecting to an EXISTING session that has an `active_execution`? In that case:
+
+1. Component mounts with `activeExecutionId = "<id>"` (from session data)
+2. Main useEffect runs: `activeExecutionIdRef.current` is set from the prop
+3. The `connect()` function is called because `activeExecutionIdRef.current` is set
+4. Connection opens, sends `subscribe` message for the active execution
+5. But what if the execution completed while the user was disconnected?
+6. The bus might have already published "complete" and the loop broke
+7. The subscribe message arrives but there's nothing to forward
+8. The frontend is stuck waiting for a "complete" event that will never come
+
+**THIS is a valid scenario.** If the user refreshes the page or reconnects while an execution is completing, the "complete" event may be lost because the bus has already finished. The `subscribe` message might arrive after the bus is completed, and the replay may or may not include the "complete" event depending on timing.
+
+But the user's report says the issue happens during normal E2E testing, not during reconnection. So this reconnection scenario may not be the primary cause.
+
+**Revised conclusion (final):**
+
+The most likely root cause is a combination of:
+1. The `complete` event IS being sent and received, and `handleComplete` IS being called
+2. BUT the `activeExecutionId` effect closes the WebSocket connection shortly after
+3. When the connection closes, the `ws.addEventListener("close")` handler triggers `scheduleReconnect()`
+4. The reconnect creates a new WebSocket, which triggers the main useEffect to re-run (because `handleMessage` dependency might change if `clearCompleteTimeout` was called)
+5. This re-run could cause the `isFirstMountRef.current` to be reset, leading to a brief reconnection flicker
+
+Actually, no. The main useEffect only re-runs if its dependencies change. `handleMessage` depends on `clearCompleteTimeout` which depends on `[]`, so both are stable.
+
+I need to step back and consider the possibility that I cannot fully identify the bug through static analysis alone. The issue may require runtime debugging (console logs in the WebSocket debug panel, network tab inspection, etc.) to confirm.
+
+Given this, the solution should address both the confirmed issues and add defensive measures:
+
+---
+
+## Solution Options
+
+### Option 1: Add Defensive Complete Event Handling
+
+**Architecture & Design:**
+
+Add multiple safety nets to ensure streaming state is always cleared:
+
+1. **Handle `execution_status` as a fallback completion signal**: Currently, `execution_status` with `status: "completed"` is never forwarded to the frontend (the loop breaks after "complete"). If we make the frontend also treat this event as a completion signal, it provides a fallback.
+
+2. **Add a connection-state-aware guard in the `activeExecutionId` effect**: Prevent the effect from closing the WebSocket if streaming is still in progress (based on the bus being active).
+
+3. **Add a timeout-based cleanup**: If `isStreaming` stays `true` for more than 30 seconds after the last token, force-clear it.
+
+**UX Design:**
+
+No visible UX changes. The fix is purely internal state management.
+
+**Implementation:**
+
+Key changes:
+- `backend/app/api/routes/ai_chat.py`: Move the `execution_status` event publishing BEFORE the `complete` event, so it's always forwarded
+- `frontend/src/features/ai/chat/api/useStreamingChat.ts`: Handle `execution_status` with `status: "completed"` as a fallback for calling `onComplete` if it hasn't been called yet
+- `frontend/src/features/ai/chat/components/ChatInterface.tsx`: Add a stale-streaming cleanup effect with a timeout
+
+**Trade-offs:**
+
+| Aspect          | Assessment                 |
+| --------------- | -------------------------- |
+| Pros            | Multiple safety nets, defensive against various failure modes |
+| Cons            | Slightly more complex, backend change required, may mask root cause |
+| Complexity      | Medium                     |
+| Maintainability | Fair                       |
+| Performance     | No impact                  |
+
+---
+
+### Option 2: Fix the Backend Event Ordering + Frontend `activeExecutionId` Effect
+
+**Architecture & Design:**
+
+Fix the root cause by ensuring the event flow is correct:
+
+1. **Backend: Publish `execution_status` BEFORE `complete`**: This ensures the frontend receives both events. The `forward_bus_events` loop should break on `complete` (terminal), but `execution_status` should be sent first.
+
+2. **Frontend: Make the `activeExecutionId` effect smarter**: Don't close the WebSocket when the completion just happened. Add a flag to track recent completion and skip the close logic.
+
+3. **Frontend: Add a stale streaming timeout**: If `isStreaming` is `true` for more than 15 seconds after last token/activity, force clear it.
+
+**UX Design:**
+
+No visible UX changes. The fix ensures clean state transitions.
+
+**Implementation:**
+
+- `backend/app/ai/agent_service.py`: Swap the order of `execution_status` and `complete` event publishing (publish `execution_status` first)
+- `frontend/src/features/ai/chat/api/useStreamingChat.ts`: Add a `recentlyCompletedRef` flag set in the complete handler, checked in the `activeExecutionId` effect to skip closing
+- `frontend/src/features/ai/chat/components/ChatInterface.tsx`: Add a `useEffect` that watches `isStreaming` and sets a timeout to force-clear it if stuck for 15+ seconds
+
+**Trade-offs:**
+
+| Aspect          | Assessment                 |
+| --------------- | -------------------------- |
+| Pros            | Fixes root cause (event ordering), minimal changes, adds defensive timeout |
+| Cons            | Backend change needed, two-file fix |
+| Complexity      | Low                        |
+| Maintainability | Good                       |
+| Performance     | No impact                  |
+
+---
+
+### Option 3: Frontend-Only Fix with Fallback Completion Detection
+
+**Architecture & Design:**
+
+Keep the backend unchanged and make the frontend resilient to missing "complete" events:
+
+1. **Frontend: Add a stale-streaming timeout in `ChatInterface`**: If `isStreaming` is `true` and no tokens have been received for 10 seconds after the last activity, force-clear all streaming state.
+
+2. **Frontend: Use `execution_status` as implicit completion**: The `onExecutionStatus` callback already fires for `execution_status` events. Add logic to treat `status: "completed"` as a fallback trigger to call `handleComplete`.
+
+3. **Frontend: Fix the `activeExecutionId` effect to not close during/after streaming**: Track whether streaming recently completed and skip the WebSocket close.
+
+**UX Design:**
+
+No visible UX changes. Adds resilience to missing events.
+
+**Implementation:**
+
+- `frontend/src/features/ai/chat/api/useStreamingChat.ts`:
+  - In `handleMessage`, treat `execution_status` with `status: "completed"` as a fallback: call `callbacks.onComplete()` if it hasn't been called recently
+  - Add `recentlyCompletedRef` flag to prevent `activeExecutionId` effect from closing connection after completion
+- `frontend/src/features/ai/chat/components/ChatInterface.tsx`:
+  - Add a `useEffect` watching `isStreaming` that sets a 15-second timeout to force-clear
+
+**Trade-offs:**
+
+| Aspect          | Assessment                 |
+| --------------- | -------------------------- |
+| Pros            | No backend changes, fully defensive, works even if events are lost |
+| Cons            | Does not fix root cause (missing `execution_status` event), timeout adds delay before recovery |
+| Complexity      | Low                        |
+| Maintainability | Good                       |
+| Performance     | No impact                  |
+
+---
+
+## Comparison Summary
+
+| Criteria           | Option 1                         | Option 2                      | Option 3                     |
+| ------------------ | -------------------------------- | ----------------------------- | ---------------------------- |
+| Development Effort | Medium (backend + frontend)      | Low (backend swap + frontend) | Low (frontend only)          |
+| UX Quality         | Good (multiple safety nets)      | Good (fixes root cause)       | Good (fallback detection)    |
+| Flexibility        | High (defensive layers)          | Medium (targeted fix)         | High (resilient to failures) |
+| Best For           | Maximum reliability              | Clean fix of root cause       | Quick fix, no backend change |
+| Risk               | Medium (may mask other issues)   | Low (addresses ordering bug)  | Low (additive, no removals)  |
+
+---
+
+## Recommendation
+
+**I recommend Option 2 because:** It fixes the root cause (backend event ordering) while also adding a defensive timeout on the frontend. The backend change is trivial (swapping two publish calls), and the frontend changes are surgical. The `activeExecutionId` effect connection management is a genuine concern that should be addressed with a "recently completed" guard.
+
+**Alternative consideration:** If you want to avoid any backend changes, Option 3 provides a frontend-only fallback that would also resolve the issue, albeit with a potential 15-second delay before the stale state is cleared.
+
+---
+
+## Decision Questions
+
+1. Should we fix the backend event ordering (publish `execution_status` before `complete`) or keep it frontend-only?
+2. Is a 15-second stale-streaming timeout acceptable, or should it be shorter/longer?
+3. Should the `activeExecutionId` effect be removed entirely (let the WebSocket lifecycle manage itself), or should it be kept with a guard?
+
+---
+
+## References
+
+- `frontend/src/features/ai/chat/api/useStreamingChat.ts` -- WebSocket hook
+- `frontend/src/features/ai/chat/components/ChatInterface.tsx` -- Main chat UI component
+- `frontend/src/features/ai/chat/types.ts` -- WebSocket message types and type guards
+- `backend/app/api/routes/ai_chat.py` -- WebSocket endpoint and `forward_bus_events`
+- `backend/app/ai/agent_service.py` -- Agent execution and event publishing
+- `backend/app/ai/execution/agent_event_bus.py` -- Event bus implementation

--- a/docs/03-project-plan/iterations/2026-05-01-fix-ai-chat-streaming-completion/01-plan.md
+++ b/docs/03-project-plan/iterations/2026-05-01-fix-ai-chat-streaming-completion/01-plan.md
@@ -1,0 +1,348 @@
+# Plan: Fix AI Chat Streaming Completion
+
+**Created:** 2026-05-01
+**Based on:** [00-analysis.md](./00-analysis.md)
+**Approved Option:** Option 2 -- Fix backend event ordering + frontend `activeExecutionId` guard + stale-streaming timeout
+
+---
+
+## Scope & Success Criteria
+
+### Approved Approach Summary
+
+- **Selected Option**: Option 2 from analysis
+- **Architecture**: Three surgical changes across backend and frontend to fix the event ordering root cause and add two defensive guards
+- **Key Decisions**:
+  1. Swap `execution_status` to publish BEFORE `complete`/`error` in `agent_service.py` (both success and error paths)
+  2. Add `recentlyCompletedRef` in `useStreamingChat.ts` to prevent the `activeExecutionId` effect from closing the WebSocket after a completion event
+  3. Add a 15-second stale-streaming timeout in `ChatInterface.tsx` as a safety net for edge cases where events are lost
+
+### Success Criteria
+
+**Functional Criteria:**
+
+- [ ] AC-1: After an AI response completes, `isStreaming` transitions to `false` within 2 seconds VERIFIED BY: manual E2E test + backend unit test
+- [ ] AC-2: After completion, the stop button disappears and the textarea re-enables VERIFIED BY: manual E2E observation
+- [ ] AC-3: Users can send follow-up messages without page refresh after a completion VERIFIED BY: manual E2E test (send message, wait for completion, send another message)
+- [ ] AC-4: The `execution_status` event with `status: "completed"` is forwarded to the frontend BEFORE the `complete` event VERIFIED BY: backend unit test on event ordering
+- [ ] AC-5: The `execution_status` event with `status: "error"` is forwarded to the frontend BEFORE the `error` event VERIFIED BY: backend unit test on error path ordering
+- [ ] AC-6: If `isStreaming` stays `true` for 15 seconds with no activity, all streaming state is force-cleared VERIFIED BY: frontend unit test with fake timers
+
+**Technical Criteria:**
+
+- [ ] AC-7: Backend: MyPy strict mode passes on `agent_service.py` VERIFIED BY: `uv run mypy app/ai/agent_service.py`
+- [ ] AC-8: Backend: Ruff passes on `agent_service.py` VERIFIED BY: `uv run ruff check app/ai/agent_service.py`
+- [ ] AC-9: Frontend: TypeScript strict mode passes on modified files VERIFIED BY: `npm run typecheck`
+- [ ] AC-10: Frontend: ESLint passes on modified files VERIFIED BY: `npm run lint`
+- [ ] AC-11: The `activeExecutionId` effect does NOT close the WebSocket within 5 seconds of `onComplete` being called VERIFIED BY: frontend unit test
+
+### Scope Boundaries
+
+**In Scope:**
+
+- Swap `_publish("execution_status")` before `_publish("complete")` in `agent_service.py` success path (lines ~1801-1810)
+- Swap `event_bus.publish("execution_status")` before `event_bus.publish("error")` in `agent_service.py` error path (lines ~1970-1991)
+- Add `recentlyCompletedRef` to `useStreamingChat.ts` and guard the `activeExecutionId` effect (lines ~1111-1122)
+- Add stale-streaming timeout `useEffect` to `ChatInterface.tsx`
+
+**Out of Scope:**
+
+- Refactoring the WebSocket connection lifecycle
+- Changing the `forward_bus_events` loop break logic
+- Adding reconnection retry logic
+- Handling the reconnection-to-completed-execution scenario (separate issue)
+- Any changes to the event bus or runner manager
+
+---
+
+## Work Decomposition
+
+### Task Breakdown
+
+| #   | Task                                                                                         | Files                                                    | Dependencies  | Success Criteria                                             | Complexity |
+| --- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ------------- | ------------------------------------------------------------ | ---------- |
+| 1   | Swap `execution_status` publish order before `complete` and `error` in `agent_service.py`    | `backend/app/ai/agent_service.py`                        | none          | AC-4, AC-5: `execution_status` arrives before `complete`/`error` | Low        |
+| 2   | Add `recentlyCompletedRef` guard to `activeExecutionId` effect in `useStreamingChat.ts`      | `frontend/src/features/ai/chat/api/useStreamingChat.ts`  | none          | AC-11: WebSocket not closed within 5s of completion          | Low        |
+| 3   | Add stale-streaming timeout `useEffect` in `ChatInterface.tsx`                               | `frontend/src/features/ai/chat/components/ChatInterface.tsx` | none          | AC-6: Streaming force-cleared after 15s idle                | Low        |
+| 4   | Backend tests for event ordering                                                             | `backend/tests/unit/ai/test_agent_service_events.py`     | Task 1        | AC-4, AC-5 verified by automated tests                      | Medium     |
+| 5   | Frontend tests for `recentlyCompletedRef` guard and stale-streaming timeout                  | `frontend/src/features/ai/chat/` tests                   | Tasks 2, 3    | AC-11, AC-6 verified by automated tests                     | Medium     |
+| 6   | Integration verification: full E2E chat flow                                                 | manual                                                   | Tasks 1-5     | AC-1, AC-2, AC-3                                            | Low        |
+
+### Test-to-Requirement Traceability
+
+| Acceptance Criterion | Test ID | Test File / Location                                          | Expected Behavior                                                             |
+| -------------------- | ------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| AC-4                 | T-001   | `backend/tests/unit/ai/test_agent_service_events.py`         | `_run_agent_graph` publishes `execution_status` before `complete`             |
+| AC-5                 | T-002   | `backend/tests/unit/ai/test_agent_service_events.py`         | Error path publishes `execution_status` before `error`                        |
+| AC-11                | T-003   | Frontend unit test (useStreamingChat)                         | `activeExecutionId` effect skips WebSocket close when `recentlyCompletedRef` is true |
+| AC-6                 | T-004   | Frontend unit test (ChatInterface)                            | Stale-streaming timeout clears all streaming state after 15s                  |
+
+---
+
+## Test Specification
+
+### Test Hierarchy
+
+```text
+├── Backend Unit Tests
+│   ├── T-001: Event ordering in success path
+│   └── T-002: Event ordering in error path
+├── Frontend Unit Tests
+│   ├── T-003: recentlyCompletedRef guard behavior
+│   └── T-004: Stale-streaming timeout behavior
+└── Manual E2E Verification
+    └── Full chat flow (send, complete, follow-up)
+```
+
+### Test Cases
+
+| Test ID | Test Name                                                       | Criterion | Type   | Verification                                                                                       |
+| ------- | --------------------------------------------------------------- | --------- | ------ | -------------------------------------------------------------------------------------------------- |
+| T-001   | `test_run_agent_graph_publishes_execution_status_before_complete` | AC-4      | Unit   | Mock the event bus publish calls; verify `execution_status` call index < `complete` call index     |
+| T-002   | `test_run_agent_graph_error_path_publishes_execution_status_before_error` | AC-5      | Unit   | Mock event bus in error path; verify `execution_status` call index < `error` call index            |
+| T-003   | `test_activeExecutionId_effect_does_not_close_ws_after_recent_completion` | AC-11     | Unit   | Set `recentlyCompletedRef.current = true`, trigger effect with `activeExecutionId = null`, verify `wsRef.current.close()` NOT called |
+| T-004   | `test_stale_streaming_timeout_clears_state_after_15s`           | AC-6      | Unit   | Set `isStreaming = true`, advance Jest timers by 15s, verify all streaming state cleared           |
+
+### Test Infrastructure Needs
+
+- **Backend T-001/T-002**: Mock `_publish` function or `AgentEventBus.publish`; need a test fixture that captures publish call order. The existing `_publish` is a local function inside `_run_agent_graph`, so the test should either mock the event bus or use a spy on `AgentEventBus.publish`.
+- **Frontend T-003**: Mock `WebSocket`, render `useStreamingChat` hook with `activeExecutionId` transitions. Use `@testing-library/react-hooks` or `renderHook`.
+- **Frontend T-004**: Use `vi.useFakeTimers()` in Vitest to advance time. Render `ChatInterface` component or test the effect in isolation.
+
+---
+
+## Detailed Task Specifications
+
+### Task 1: Swap `execution_status` publish order in `agent_service.py`
+
+**File**: `backend/app/ai/agent_service.py`
+
+**Success path (lines ~1789-1810)** -- current order:
+1. `_publish("agent_complete", ...)` (line 1780)
+2. `_publish("complete", WSCompleteMessage(...))` (line 1791)
+3. `_publish("execution_status", ...)` (line 1802) -- NEVER FORWARDED because loop breaks on "complete"
+
+**Required new order:**
+1. `_publish("agent_complete", ...)` (unchanged)
+2. `_publish("execution_status", ...)` -- MOVE HERE (before complete)
+3. `_publish("complete", WSCompleteMessage(...))` -- MOVE HERE (after execution_status)
+
+**Error path (lines ~1970-1991)** -- current order:
+1. `event_bus.publish(AgentEvent(event_type="error", ...))` (line 1971)
+2. `event_bus.publish(AgentEvent(event_type="execution_status", ...))` (line 1980) -- NEVER FORWARDED because loop breaks on "error"
+
+**Required new order:**
+1. `event_bus.publish(AgentEvent(event_type="execution_status", ...))` -- MOVE HERE (before error)
+2. `event_bus.publish(AgentEvent(event_type="error", ...))` -- MOVE HERE (after execution_status)
+
+**Success Criteria**: AC-4, AC-5
+
+---
+
+### Task 2: Add `recentlyCompletedRef` guard to `activeExecutionId` effect
+
+**File**: `frontend/src/features/ai/chat/api/useStreamingChat.ts`
+
+**Changes**:
+
+A. Add a new ref near the existing refs (around line ~50-80):
+   ```typescript
+   const recentlyCompletedRef = useRef(false);
+   ```
+
+B. In the `isCompleteMessage` handler (around line 571-581), after `callbacks.onComplete(...)`, set the ref:
+   ```typescript
+   recentlyCompletedRef.current = true;
+   setTimeout(() => { recentlyCompletedRef.current = false; }, 5000);
+   ```
+   This gives the `activeExecutionId` effect a 5-second window to skip closing.
+
+C. In the `isErrorMessage` handler (around line 584-589), after the error handling, also set:
+   ```typescript
+   recentlyCompletedRef.current = true;
+   setTimeout(() => { recentlyCompletedRef.current = false; }, 5000);
+   ```
+
+D. In the `activeExecutionId` effect (lines 1111-1122), add a guard:
+   ```typescript
+   } else if (!activeExecutionId && wsRef.current) {
+     // Don't close if we just completed streaming -- the connection
+     // should stay alive for follow-up messages
+     if (recentlyCompletedRef.current) {
+       return;
+     }
+     wsRef.current.close();
+     wsRef.current = null;
+     setConnectionState(WSConnectionState.CLOSED);
+   }
+   ```
+
+**Success Criteria**: AC-11 -- WebSocket stays open for 5 seconds after completion
+
+---
+
+### Task 3: Add stale-streaming timeout in `ChatInterface.tsx`
+
+**File**: `frontend/src/features/ai/chat/components/ChatInterface.tsx`
+
+**Changes**:
+
+Add a new `useEffect` after the `isStreaming` computation (around line 242) that watches `isStreaming` and force-clears all streaming state if it stays `true` for more than 15 seconds:
+
+```typescript
+// Safety net: force-clear streaming state if stuck for 15+ seconds
+useEffect(() => {
+  if (!isStreaming) return;
+
+  const timeoutId = setTimeout(() => {
+    // Force-clear all streaming state
+    setIsWaitingForResponse(false);
+    setActiveToolCalls([]);
+    setStreamingState({
+      main: "",
+      mainStreams: new Map<string, MainAgentStream>(),
+      subagents: new Map<string, SubagentStream>(),
+    });
+  }, 15_000);
+
+  return () => clearTimeout(timeoutId);
+}, [isStreaming]);
+```
+
+Note: The effect re-runs when `isStreaming` changes. If it transitions to `false` before 15s, the cleanup clears the timeout. If it stays `true`, the timeout fires and resets everything.
+
+**Success Criteria**: AC-6 -- Streaming state force-cleared after 15s idle
+
+---
+
+### Task 4: Backend tests for event ordering
+
+**File**: `backend/tests/unit/ai/test_agent_service_events.py` (new file)
+
+**T-001**: Verify that in the success path, `execution_status` event is published before `complete` event.
+- Approach: Mock the `_publish` function or spy on `event_bus.publish` to record call order
+- Assert: The `execution_status` call appears before the `complete` call in the recorded sequence
+
+**T-002**: Verify that in the error path, `execution_status` event is published before `error` event.
+- Approach: Same mocking strategy, trigger error condition
+- Assert: The `execution_status` call appears before the `error` call
+
+**Success Criteria**: AC-4, AC-5
+
+---
+
+### Task 5: Frontend tests
+
+**T-003**: Test `recentlyCompletedRef` guard behavior.
+- Render `useStreamingChat` with mock WebSocket
+- Simulate `onComplete` callback invocation
+- Transition `activeExecutionId` from a value to `null`
+- Assert: `wsRef.current.close()` is NOT called within 5 seconds
+- After 5 seconds, transition `activeExecutionId` to `null` again
+- Assert: Close IS called (guard expired)
+
+**T-004**: Test stale-streaming timeout.
+- Render `ChatInterface` component (or test the effect in isolation)
+- Set `isStreaming` to `true` by simulating streaming start
+- Advance fake timers by 14 seconds
+- Assert: Streaming state NOT cleared
+- Advance fake timers by 2 more seconds (total 16s)
+- Assert: All streaming state cleared (`isStreaming === false`)
+
+**Success Criteria**: AC-6, AC-11
+
+---
+
+## Risk Assessment
+
+| Risk Type   | Description                                                                                          | Probability | Impact | Mitigation                                                                                     |
+| ----------- | ---------------------------------------------------------------------------------------------------- | ----------- | ------ | ---------------------------------------------------------------------------------------------- |
+| Technical   | 15s timeout may be too short for very long agent responses with legitimate pauses (tool calls)       | Low         | Low    | Tool calls reset `isStreaming` via `handleToolCall`; the timeout only fires if NO state changes for 15s |
+| Technical   | `recentlyCompletedRef` 5s window may not be enough if session refetch is slow                        | Low         | Medium | 5s is generous for a DB query; if needed, increase to 8s. The stale timeout at 15s is the ultimate fallback |
+| Integration | Backend `execution_status` before `complete` may confuse existing frontend handlers                  | Low         | Low    | `isCompleteMessage` is the ONLY handler that checks `msg.type === "complete"`. `execution_status` is handled by a separate `isExecutionStatusMessage` guard earlier in the handler chain |
+| Regression  | Moving `execution_status` before `complete` changes the bus event sequence                           | Low         | Low    | `execution_status` is NOT a terminal event (the loop does not break on it); it's already handled by the frontend |
+
+---
+
+## Documentation References
+
+### Required Reading
+
+- Analysis: `docs/03-project-plan/iterations/2026-05-01-fix-ai-chat-streaming-completion/00-analysis.md`
+- WebSocket protocol: `backend/app/api/routes/ai_chat.py` lines 60-91 (forward_bus_events)
+- Event publishing: `backend/app/ai/agent_service.py` lines 1779-1810 (success), 1970-1991 (error)
+
+### Code References
+
+- Backend event bus: `backend/app/ai/execution/agent_event_bus.py`
+- Frontend WebSocket hook: `frontend/src/features/ai/chat/api/useStreamingChat.ts`
+- Frontend streaming state: `frontend/src/features/ai/chat/components/ChatInterface.tsx`
+- Frontend type guards: `frontend/src/features/ai/chat/types.ts`
+
+---
+
+## Prerequisites
+
+### Technical
+
+- [x] Backend dev server can start (`uv run uvicorn app.main:app --reload --port 8020`)
+- [x] Frontend dev server can start (`npm run dev`)
+- [x] PostgreSQL running (`docker-compose up -d postgres`)
+- [x] No pending migrations required for this change
+
+### Documentation
+
+- [x] Analysis phase approved (Option 2)
+- [x] Source files reviewed and line numbers confirmed
+
+---
+
+# Task Dependency Graph
+
+```yaml
+# Task Dependency Graph
+tasks:
+  - id: BE-001
+    name: "Swap execution_status publish order before complete/error in agent_service.py"
+    agent: pdca-backend-do-executor
+    dependencies: []
+
+  - id: FE-001
+    name: "Add recentlyCompletedRef guard to activeExecutionId effect in useStreamingChat.ts"
+    agent: pdca-frontend-do-executor
+    dependencies: []
+
+  - id: FE-002
+    name: "Add stale-streaming timeout useEffect in ChatInterface.tsx"
+    agent: pdca-frontend-do-executor
+    dependencies: []
+
+  - id: BE-TEST-001
+    name: "Backend unit tests for event ordering (success and error paths)"
+    agent: pdca-backend-do-executor
+    dependencies: [BE-001]
+    kind: test
+
+  - id: FE-TEST-001
+    name: "Frontend unit tests for recentlyCompletedRef guard and stale-streaming timeout"
+    agent: pdca-frontend-do-executor
+    dependencies: [FE-001, FE-002]
+    kind: test
+
+  - id: VERIFY-001
+    name: "Integration verification: full E2E chat flow (send, complete, follow-up)"
+    agent: pdca-backend-do-executor
+    dependencies: [BE-TEST-001, FE-TEST-001]
+```
+
+### Execution Levels
+
+- **Level 0 (parallel)**: BE-001, FE-001, FE-002 -- all three implementation tasks can run simultaneously
+- **Level 1**: BE-TEST-001 (after BE-001), FE-TEST-001 (after FE-001 + FE-002)
+- **Level 2**: VERIFY-001 (after all tests pass)
+
+### Notes
+
+- BE-001 and FE-001/FE-002 are independent and can be delegated to separate agents in parallel
+- BE-TEST-001 and FE-TEST-001 should NOT run in parallel with each other (both are test suites, and the backend test may involve database operations)
+- VERIFY-001 is a manual verification step that confirms the full flow works end-to-end

--- a/frontend/src/components/time-machine/QuickJumpButtons.tsx
+++ b/frontend/src/components/time-machine/QuickJumpButtons.tsx
@@ -49,8 +49,6 @@ export function QuickJumpButtons({
         if (minDate && targetDate < minDate) isOutOfRange = true;
         if (maxDate && targetDate > maxDate) isOutOfRange = true;
 
-        const isBaseDateNow = !currentDate;
-
         return (
           <Tooltip key={key} title={isOutOfRange ? "Out of range" : tooltip}>
             <button
@@ -64,10 +62,7 @@ export function QuickJumpButtons({
                 minWidth: 40,
                 padding: `0 ${token.paddingSM}px`,
                 border: "none",
-                background:
-                  isBaseDateNow && label.startsWith("+")
-                    ? token.colorFillTertiary
-                    : token.colorFillSecondary,
+                background: token.colorFillSecondary,
                 color: token.colorText,
                 fontSize: 12,
                 fontWeight: 600,
@@ -79,21 +74,15 @@ export function QuickJumpButtons({
                 alignItems: "center",
                 justifyContent: "center",
                 letterSpacing: "0.02em",
-                opacity:
-                  isBaseDateNow && label.startsWith("+") ? 0.35 : undefined,
               }}
               onMouseEnter={(e) => {
-                if (!disabled && !isOutOfRange && !(isBaseDateNow && label.startsWith("+"))) {
+                if (!disabled && !isOutOfRange) {
                   e.currentTarget.style.background = token.colorFill;
                   e.currentTarget.style.transform = "translateY(-1px)";
                 }
               }}
               onMouseLeave={(e) => {
-                if (isBaseDateNow && label.startsWith("+")) {
-                  e.currentTarget.style.background = token.colorFillTertiary;
-                } else {
-                  e.currentTarget.style.background = token.colorFillSecondary;
-                }
+                e.currentTarget.style.background = token.colorFillSecondary;
                 e.currentTarget.style.transform = "translateY(0)";
               }}
             >

--- a/frontend/src/components/time-machine/TimelineSlider.tsx
+++ b/frontend/src/components/time-machine/TimelineSlider.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useRef, useCallback } from "react";
-import { Tooltip, theme } from "antd";
+import { useMemo, useCallback } from "react";
+import { Slider, theme } from "antd";
 import type { TimelineEvent } from "./types";
 import "./TimeMachine.styles.css";
 import { formatDate, formatDateTime as formatDateTimeUtil } from "@/utils/formatters";
@@ -45,175 +45,85 @@ export function TimelineSlider({
   disabled = false,
 }: TimelineSliderProps) {
   const { token } = theme.useToken();
-  const trackRef = useRef<HTMLDivElement>(null);
-  const thumbRef = useRef<HTMLDivElement>(null);
 
   // Convert dates to timestamps for slider
   const minValue = minDate.getTime();
   const maxValue = maxDate.getTime();
   const currentValue = value?.getTime() ?? maxValue;
 
-  // Calculate percentage for thumb position
-  const getPercentage = useCallback(
-    (timestamp: number) => {
-      return ((timestamp - minValue) / (maxValue - minValue)) * 100;
-    },
-    [minValue, maxValue]
-  );
-
-  const percentage = getPercentage(currentValue);
-
-  // Handle drag start
-  const handleDragStart = useCallback(() => {
-    if (disabled) return;
-  }, [disabled]);
-
-  // Handle drag end
-  const handleDragEnd = useCallback(() => {
-    if (disabled) return;
-  }, [disabled]);
-
-  // Handle track click/drag
-  const handleTrackInteraction = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (disabled || !trackRef.current) return;
-
-      const rect = trackRef.current.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const percentage = Math.max(0, Math.min(1, x / rect.width));
-      const timestamp = minValue + percentage * (maxValue - minValue);
-
-      onChange(new Date(timestamp));
-    },
-    [disabled, minValue, maxValue, onChange]
-  );
-
-  // Filter events to show as markers
+  // Filter events to show as markers (avoid edges)
   const visibleEvents = useMemo(() => {
     return events.filter((event) => {
-      const timestamp = event.timestamp.getTime();
+      const ts = event.timestamp.getTime();
       return (
-        timestamp > minValue + (maxValue - minValue) * 0.05 &&
-        timestamp < maxValue - (maxValue - minValue) * 0.05
+        ts > minValue + (maxValue - minValue) * 0.05 &&
+        ts < maxValue - (maxValue - minValue) * 0.05
       );
     });
   }, [events, minValue, maxValue]);
 
-  // Tooltip formatter
-  const formatTooltip = useCallback(
-    (timestamp: number) => {
-      return formatDateTime(new Date(timestamp));
+  // Build marks for events
+  const marks = useMemo(() => {
+    const result: Record<number, { label: string; style?: React.CSSProperties }> = {};
+    visibleEvents.forEach((event) => {
+      const ts = event.timestamp.getTime();
+      const color = getEventColor(event.type, token);
+      result[ts] = {
+        label: "",
+        style: {
+          // Small colored dot as mark label content via background
+          width: 6,
+          height: 6,
+          borderRadius: "50%",
+          background: color,
+          position: "absolute" as const,
+          top: -3,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 1,
+        },
+      };
+    });
+    return result;
+  }, [visibleEvents, token]);
+
+  const handleChange = useCallback(
+    (val: number) => {
+      onChange(new Date(val));
+    },
+    [onChange]
+  );
+
+  const tooltipFormatter = useCallback(
+    (val?: number) => {
+      if (val == null) return "";
+      return formatDateTime(new Date(val));
     },
     []
   );
 
   return (
     <div className="tm-slider-container">
-      {/* Custom Slider */}
-      <div
-        ref={trackRef}
-        className="tm-slider-track"
-        onClick={handleTrackInteraction}
-        onMouseDown={handleDragStart}
-        onMouseUp={handleDragEnd}
-        onMouseLeave={handleDragEnd}
-        role="slider"
-        aria-label="Timeline slider"
-        aria-valuemin={minValue}
-        aria-valuemax={maxValue}
-        aria-valuenow={currentValue}
-        aria-disabled={disabled}
-        tabIndex={disabled ? -1 : 0}
-        style={{
-          cursor: disabled ? "not-allowed" : "pointer",
-          opacity: disabled ? 0.5 : 1,
+      <Slider
+        min={minValue}
+        max={maxValue}
+        value={currentValue}
+        onChange={handleChange}
+        disabled={disabled}
+        tooltip={{ formatter: tooltipFormatter }}
+        marks={Object.keys(marks).length > 0 ? marks : undefined}
+        step={Math.max(1, Math.floor((maxValue - minValue) / 1000))}
+        styles={{
+          track: { background: token.colorPrimary },
+          rail: { background: token.colorBorder },
+          handle: {
+            background: token.colorBgContainer,
+            borderColor: token.colorPrimary,
+          },
         }}
-        onKeyDown={(e) => {
-          if (disabled) return;
-          const step = (maxValue - minValue) / 100;
-          let newValue = currentValue;
+      />
 
-          if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
-            newValue = Math.max(minValue, currentValue - step);
-            e.preventDefault();
-          } else if (e.key === "ArrowRight" || e.key === "ArrowUp") {
-            newValue = Math.min(maxValue, currentValue + step);
-            e.preventDefault();
-          } else if (e.key === "Home") {
-            newValue = minValue;
-            e.preventDefault();
-          } else if (e.key === "End") {
-            newValue = maxValue;
-            e.preventDefault();
-          }
-
-          if (newValue !== currentValue) {
-            onChange(new Date(newValue));
-          }
-        }}
-      >
-        {/* Fill */}
-        <div
-          className="tm-slider-fill"
-          style={{
-            width: `${percentage}%`,
-            background: token.colorPrimary,
-          }}
-        />
-
-        {/* Thumb */}
-        <Tooltip title={formatTooltip(currentValue)} placement="top">
-          <div
-            ref={thumbRef}
-            className="tm-slider-thumb"
-            style={{
-              left: `${percentage}%`,
-              background: token.colorBgContainer,
-              borderColor: token.colorPrimary,
-            }}
-            onMouseDown={(e) => {
-              e.stopPropagation();
-              handleDragStart();
-            }}
-          />
-        </Tooltip>
-
-        {/* Event Markers */}
-        {visibleEvents.map((event) => {
-          const eventPercentage = getPercentage(event.timestamp.getTime());
-          const eventColor = getEventColor(event.type, token);
-          return (
-            <Tooltip
-              key={event.id}
-              title={`${event.label} - ${formatDateTime(event.timestamp)}`}
-              placement="top"
-            >
-              <div
-                className="tm-slider-marker"
-                style={{
-                  left: `${eventPercentage}%`,
-                  background: token.colorBorder,
-                }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onChange(event.timestamp);
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.background = token.colorPrimary;
-                  e.currentTarget.style.transform = "translate(-50%, -50%) scale(1.4)";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = eventColor;
-                  e.currentTarget.style.transform = "translate(-50%, -50%) scale(1)";
-                }}
-                aria-label={`Event: ${event.label}`}
-              />
-            </Tooltip>
-          );
-        })}
-      </div>
-
-      {/* Labels */}
+      {/* Date labels */}
       <div className="tm-slider-labels">
         <span>{formatShortDate(minDate)}</span>
         <span style={{ fontWeight: 600 }}>{formatShortDate(maxDate)}</span>

--- a/frontend/src/features/ai/chat/api/useStreamingChat.ts
+++ b/frontend/src/features/ai/chat/api/useStreamingChat.ts
@@ -256,6 +256,10 @@ export const useStreamingChat = (
   // Timeout reference for reconnection delays
   const reconnectTimeoutRef = useRef<number | null>(null);
 
+  // Guard: prevents the activeExecutionId effect from closing the WebSocket
+  // shortly after a completion or error event (5 s window)
+  const recentlyCompletedRef = useRef(false);
+
   // Store callbacks in refs to avoid useEffect re-running when they change
   const callbacksRef = useRef({
     onToken,
@@ -574,6 +578,10 @@ export const useStreamingChat = (
         activeExecutionIdRef.current = null;
         lastSequenceRef.current = 0;
         callbacks.onComplete(serverMessage.session_id, serverMessage.message_id, serverMessage.token_usage ?? undefined);
+        // Mark as recently completed to prevent the activeExecutionId
+        // effect from closing the WebSocket connection immediately
+        recentlyCompletedRef.current = true;
+        setTimeout(() => { recentlyCompletedRef.current = false; }, 5000);
         // Keep connection alive — do NOT close here.
         // The connection will be closed when the component unmounts
         // or the user explicitly cancels (via the cancel() function).
@@ -602,6 +610,10 @@ export const useStreamingChat = (
         callbacks.onError(errorMsg);
         setError(new Error(errorMsg));
         setConnectionState(WSConnectionState.ERROR);
+        // Mark as recently completed to prevent the activeExecutionId
+        // effect from closing the WebSocket connection immediately
+        recentlyCompletedRef.current = true;
+        setTimeout(() => { recentlyCompletedRef.current = false; }, 5000);
         // Force-close the potentially broken connection to trigger reconnect
         if (wsRef.current) {
           try {
@@ -1113,6 +1125,11 @@ export const useStreamingChat = (
       // Connect if we have an active execution and no existing connection
       connectRef.current?.();
     } else if (!activeExecutionId && wsRef.current) {
+      // Don't close if we just completed streaming -- the connection
+      // should stay alive for follow-up messages
+      if (recentlyCompletedRef.current) {
+        return;
+      }
       // Disconnect if switching to a non-running session
       // Only close if we're not in the middle of sending a message
       wsRef.current.close();

--- a/frontend/src/features/ai/chat/components/ChatInterface.tsx
+++ b/frontend/src/features/ai/chat/components/ChatInterface.tsx
@@ -240,6 +240,19 @@ export const ChatInterface = ({
     [streamingState.main, streamingState.mainStreams, streamingState.subagents, activeToolCalls.length, isWaitingForResponse]
   );
 
+  // Safety net: clear waiting spinner if stuck for 15+ seconds.
+  // Does NOT clear streaming content — that would make visible bubbles disappear.
+  // The WebSocket layer handles connection-level timeouts.
+  useEffect(() => {
+    if (!isWaitingForResponse) return;
+
+    const timeoutId = setTimeout(() => {
+      setIsWaitingForResponse(false);
+    }, 15_000);
+
+    return () => clearTimeout(timeoutId);
+  }, [isWaitingForResponse]);
+
   // Clear optimistic user message when persisted messages arrive
   useEffect(() => {
     if (pendingUserMessage && messages) {

--- a/frontend/src/features/ai/components/AIAssistantList.tsx
+++ b/frontend/src/features/ai/components/AIAssistantList.tsx
@@ -178,7 +178,7 @@ export const AIAssistantList = () => {
               data: values,
             });
           } else {
-            await createAssistant(payload as AIAssistantCreate);
+            await createAssistant(values as AIAssistantCreate);
           }
         }}
         confirmLoading={isLoading}


### PR DESCRIPTION
## Summary

Major overhaul of the AI agent architecture, replacing the flat subagent-as-tool pattern with a supervisor orchestrator using a briefing room pattern for coordinated multi-specialist analysis.

### Key changes across 35 commits:

**Supervisor Orchestrator & Briefing System**
- New `SupervisorOrchestrator` with LangGraph native supervisor pattern
- Briefing room: specialists contribute findings to a shared briefing document
- Briefing injected as SystemMessage so supervisor always has context
- Specialist findings extraction hardened for models with empty final responses (e.g. DeepSeek)

**Streaming & WebSocket Reliability**
- Fix race condition in `AgentEventBus`: mark completed AFTER delivering terminal events to queues
- Extract `forward_bus_events()` helper with queue draining on bus completion
- Add `recentlyCompletedRef` to prevent premature WebSocket close after streaming
- 15s safety net for stuck waiting spinner in ChatInterface
- Event dispatch optimization: skip ~40-60% of unhandled LangGraph events

**DeepSeek Model Compatibility**
- Strip `tool_choice` for DeepSeek models to prevent `bind_tools` crash
- Preserve `reasoning_content` across turns and specialist delegation
- Fix EVM specialist recursion crash

**Code Quality & Refactoring**
- Extract `filter_tools_for_context()` and `build_backcast_middleware()` shared helpers
- Add `OrchestratorMode` enum, remove `use_supervisor` from `AgentConfig`
- Replace typed WS message constructors with plain dicts in dispatch loop
- Consolidate briefing publish into `_publish_briefing_update()` helper
- Simplified logging (lazy `%s` formatting, removed verbose f-string debug logs)

**Frontend AI Chat UX**
- Briefing rail UI showing real-time specialist findings
- Briefing persistence to database on completion and error paths
- Show briefing when reopening past chat sessions
- Animated wave background on all pages
- Replace broken custom slider with antd Slider in time machine

**Bug Fixes**
- Fix AIAssistantList using stale `payload` instead of `values`
- Ensure `end_date` always included in EVM time-series date intervals
- Remove harmful `...mutationOptions` spread from mutation hooks
- Fix progress entries temporal serialization

## Test plan
- [ ] AI chat sends messages and receives streaming responses
- [ ] Supervisor orchestrator delegates to correct specialists
- [ ] Briefing rail updates in real-time during specialist execution
- [ ] WebSocket stays connected after completion for follow-up messages
- [ ] Waiting spinner clears within 15s even if no response
- [ ] EVM time-series charts include end_date data point
- [ ] DeepSeek models work without tool_choice errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)