### PR TITLE
feat(website): Backcast showcase site

### DIFF
--- a/website/css/styles.css
+++ b/website/css/styles.css
@@ -1,0 +1,298 @@
+/* =============================================================================
+   Backcast Showcase — component & page styles
+   Assembled from the Serif design system (see .claude/skills/website/design-system.md).
+   tokens.css must be linked first. Every design value is a token — no hardcoded
+   colors/sizes; extend tokens.css if a value is missing.
+   ========================================================================== */
+
+/* ---------------------------------------------------------------------------
+   Reveal on scroll (paired with [data-reveal] + main.js IntersectionObserver)
+--------------------------------------------------------------------------- */
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(14px);
+  transition: opacity 600ms var(--ease), transform 600ms var(--ease);
+}
+[data-reveal].is-visible { opacity: 1; transform: none; }
+/* Stagger chat prompts as they enter */
+.prompts .prompt:nth-child(2) { transition-delay: 80ms; }
+.prompts .prompt:nth-child(3) { transition-delay: 160ms; }
+.prompts .prompt:nth-child(4) { transition-delay: 240ms; }
+
+/* ---------------------------------------------------------------------------
+   Header / navigation
+--------------------------------------------------------------------------- */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--background-translucent);
+  -webkit-backdrop-filter: saturate(140%) blur(8px);
+  backdrop-filter: saturate(140%) blur(8px);
+  border-bottom: 1px solid var(--border);
+}
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-6);
+  min-height: var(--header-h);
+}
+.wordmark {
+  font-family: var(--font-display);
+  font-size: var(--text-h3);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+}
+.wordmark:hover { color: var(--accent); }
+
+/* Hamburger (mobile only) */
+.nav-toggle {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  min-width: 44px;
+  min-height: 44px;
+  padding: var(--space-2);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+.nav-toggle span {
+  width: 24px;
+  height: 1.5px;
+  background: var(--foreground);
+  transition: opacity var(--transition-fast);
+}
+.nav-toggle[aria-expanded="true"] span:nth-child(2) { opacity: 0; }
+
+/* Mobile dropdown panel */
+.primary-nav {
+  position: absolute;
+  top: var(--header-h);
+  left: 0;
+  right: 0;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  padding: var(--space-2) var(--space-6) var(--space-6);
+  background: var(--background);
+  border-bottom: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+  display: none;
+}
+.primary-nav.is-open { display: flex; }
+.primary-nav a:not(.btn) {
+  padding-block: var(--space-4);
+  border-bottom: 1px solid var(--border);
+  font-size: var(--text-nav);
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  color: var(--muted-foreground);
+  transition: color var(--transition-fast);
+}
+.primary-nav a:not(.btn):hover { color: var(--foreground); }
+.primary-nav .btn { margin-top: var(--space-4); }
+
+/* ---------------------------------------------------------------------------
+   Section label (flanking rules + small caps)
+--------------------------------------------------------------------------- */
+.section-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+  max-width: 26rem;
+}
+.section-label__rule { height: 1px; flex: 1; background: var(--border); }
+.section-label__text { color: var(--accent); white-space: nowrap; }
+.section-label--center { justify-content: center; max-width: 26rem; margin-inline: auto; }
+.section-label--start { max-width: none; }
+.section-label--start .section-label__rule:last-child { display: none; }
+
+/* ---------------------------------------------------------------------------
+   Buttons
+--------------------------------------------------------------------------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: 44px;
+  padding: 0 var(--space-6);
+  font-family: var(--font-body);
+  font-size: var(--text-nav);
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  touch-action: manipulation;
+  text-align: center;
+  transition: background-color var(--transition), color var(--transition),
+              border-color var(--transition), box-shadow var(--transition),
+              transform var(--transition);
+}
+.btn--primary { background: var(--accent); color: var(--accent-foreground); box-shadow: var(--shadow-sm); }
+.btn--primary:hover { background: var(--accent-secondary); box-shadow: var(--shadow-accent); transform: translateY(-2px); }
+.btn--primary:active { transform: translateY(0); }
+
+.btn--outline { background: transparent; color: var(--foreground); border-color: var(--foreground); }
+.btn--outline:hover { background: var(--muted); color: var(--accent); border-color: var(--accent); }
+
+.btn--ghost { background: transparent; color: var(--muted-foreground); padding-inline: 0; }
+.btn--ghost:hover { color: var(--foreground); text-decoration: underline; text-decoration-color: var(--accent); text-underline-offset: 4px; }
+
+.btn--block { display: flex; width: 100%; }
+
+/* ---------------------------------------------------------------------------
+   Cards
+--------------------------------------------------------------------------- */
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: var(--space-8);
+  transition: box-shadow var(--transition), border-color var(--transition), background-color var(--transition);
+}
+.card--hover:hover { box-shadow: var(--shadow-md); border-color: var(--border-hover); background: var(--muted-50); }
+.card--accent-top { border-top: 2px solid var(--accent); }
+.card--elevated { box-shadow: var(--shadow-md); }
+.card--featured { background: var(--accent-muted); border-top: 2px solid var(--accent); box-shadow: var(--shadow-md); }
+.card__index { display: block; color: var(--accent); margin-bottom: var(--space-4); }
+.card__title { font-size: var(--text-card-title); margin-bottom: var(--space-3); }
+.card__body { color: var(--muted-foreground); max-width: 42ch; }
+
+/* ---------------------------------------------------------------------------
+   Hero / CTA
+--------------------------------------------------------------------------- */
+.hero, .cta { text-align: center; }
+.hero__inner, .cta__inner { display: flex; flex-direction: column; align-items: center; }
+.hero__title { font-size: clamp(2.5rem, 7vw, var(--text-hero)); line-height: 1.1; max-width: 16ch; }
+.cta__title { font-size: clamp(2.5rem, 6vw, var(--text-h2)); }
+.lede { font-size: var(--text-body-lg); color: var(--muted-foreground); max-width: 54ch; margin-top: var(--space-6); }
+.hero__cta { display: flex; flex-wrap: wrap; gap: var(--space-4); justify-content: center; margin-top: var(--space-10); }
+
+/* ---------------------------------------------------------------------------
+   Pillars (differentiators at a glance)
+--------------------------------------------------------------------------- */
+.pillars { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--space-8); grid-template-columns: 1fr; }
+.pillar { padding-top: var(--space-4); border-top: 1px solid var(--border); }
+.pillar__title { font-family: var(--font-display); font-size: var(--text-card-title); margin-bottom: var(--space-2); }
+.pillar__body { color: var(--muted-foreground); font-size: var(--text-nav); max-width: 30ch; }
+
+/* ---------------------------------------------------------------------------
+   Thesis (asymmetric benefits layout)
+--------------------------------------------------------------------------- */
+.benefits__grid { display: grid; gap: var(--space-12); grid-template-columns: 1fr; }
+.benefits__title { font-size: var(--text-h2); max-width: 18ch; margin-bottom: var(--space-6); }
+.benefits__lead p { color: var(--muted-foreground); font-size: var(--text-body-lg); max-width: 52ch; }
+.benefits__points { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: var(--space-4); }
+.benefit { display: flex; gap: var(--space-3); align-items: baseline; font-size: var(--text-body-lg); }
+.benefit__mark { color: var(--accent); }
+
+/* ---------------------------------------------------------------------------
+   Features (capabilities)
+--------------------------------------------------------------------------- */
+.features__title { font-size: var(--text-h2); max-width: 22ch; margin-bottom: var(--space-12); }
+.features__grid { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--space-8); grid-template-columns: 1fr; }
+
+/* ---------------------------------------------------------------------------
+   In action — chat prompts (progressive disclosure via scroll reveal)
+--------------------------------------------------------------------------- */
+.action__title { font-size: var(--text-h2); max-width: 16ch; }
+.action__intro { color: var(--muted-foreground); font-size: var(--text-body-lg); max-width: 54ch; margin-top: var(--space-6); }
+.prompts { margin-top: var(--space-12); display: flex; flex-direction: column; gap: var(--space-6); }
+.prompt {
+  margin: 0;
+  border-left: 2px solid var(--accent);
+  background: var(--muted);
+  padding: var(--space-5) var(--space-6);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+}
+.prompt__command { font-family: var(--font-display); font-style: italic; font-size: var(--text-card-title); line-height: 1.5; }
+.prompt__label { font-style: normal; color: var(--accent); margin-right: var(--space-3); }
+.prompt__outcome { margin-top: var(--space-3); color: var(--muted-foreground); max-width: 64ch; }
+
+/* ---------------------------------------------------------------------------
+   Under the hood — accordions (depth on demand)
+--------------------------------------------------------------------------- */
+.how__title { font-size: var(--text-h2); max-width: 16ch; }
+.how__intro { color: var(--muted-foreground); font-size: var(--text-body-lg); max-width: 54ch; margin-top: var(--space-6); }
+.accordions { margin-top: var(--space-10); }
+.accordion { border-top: 1px solid var(--border); }
+.accordion__trigger {
+  width: 100%; display: flex; justify-content: space-between; align-items: center; gap: var(--space-4);
+  min-height: 44px; padding-block: var(--space-5);
+  background: transparent; border: 0; border-bottom: 1px solid var(--border);
+  font-family: var(--font-display); font-size: var(--text-card-title); text-align: left;
+  cursor: pointer; touch-action: manipulation; color: var(--foreground);
+  transition: color var(--transition-fast);
+}
+.accordion__trigger:hover { color: var(--accent); }
+.accordion__trigger::after { content: "+"; margin-left: auto; font-family: var(--font-mono); font-weight: 500; color: var(--accent); }
+.accordion.is-open .accordion__trigger::after { content: "\2212"; }
+.accordion__panel { padding-block: var(--space-4) var(--space-6); color: var(--muted-foreground); }
+.accordion__panel p { max-width: 64ch; }
+
+/* ---------------------------------------------------------------------------
+   Get started — code block + links
+--------------------------------------------------------------------------- */
+.code {
+  margin-top: var(--space-8);
+  font-family: var(--font-mono); font-size: var(--text-nav); line-height: 1.8;
+  background: var(--foreground); color: var(--background);
+  padding: var(--space-6); border-radius: var(--radius-md);
+  overflow-x: auto; white-space: pre;
+}
+.start__links { display: flex; flex-wrap: wrap; gap: var(--space-6); margin-top: var(--space-8); }
+
+/* ---------------------------------------------------------------------------
+   Live demo — credentials
+--------------------------------------------------------------------------- */
+.creds { display: flex; flex-wrap: wrap; gap: var(--space-8) var(--space-12); justify-content: center; margin-top: var(--space-10); margin-bottom: 0; }
+.cred { text-align: left; }
+.cred__label { color: var(--muted-foreground); margin-bottom: var(--space-1); }
+.cred__value { font-family: var(--font-mono); font-size: var(--text-body); color: var(--foreground); margin: 0; }
+
+/* ---------------------------------------------------------------------------
+   Footer
+--------------------------------------------------------------------------- */
+.site-footer { border-top: 1px solid var(--border); padding-block: var(--space-12); }
+.site-footer__inner { display: flex; flex-direction: column; gap: var(--space-6); }
+.site-footer__nav { display: flex; flex-wrap: wrap; gap: var(--space-6); }
+.site-footer__nav a { font-size: var(--text-nav); font-weight: 500; letter-spacing: 0.05em; color: var(--muted-foreground); }
+.site-footer__nav a:hover { color: var(--foreground); }
+.site-footer .small-caps { color: var(--muted-foreground); }
+
+/* ---------------------------------------------------------------------------
+   Responsive — mobile-first; enhance from 768px / 1024px
+--------------------------------------------------------------------------- */
+@media (min-width: 768px) {
+  /* Desktop nav: hide hamburger, show inline */
+  .nav-toggle { display: none; }
+  .primary-nav {
+    position: static; display: flex; flex-direction: row; align-items: center; gap: var(--space-8);
+    padding: 0; background: transparent; border: 0; box-shadow: none;
+  }
+  .primary-nav a:not(.btn) { padding-block: 0; border-bottom: 0; }
+  .primary-nav .btn { margin-top: 0; }
+
+  .pillars { grid-template-columns: repeat(2, 1fr); }
+  .features__grid { grid-template-columns: repeat(3, 1fr); }
+  .benefits__grid { grid-template-columns: 1.3fr 0.7fr; align-items: start; }
+  .site-footer__inner { flex-direction: row; flex-wrap: wrap; justify-content: space-between; align-items: center; }
+}
+
+@media (min-width: 1024px) {
+  .pillars { grid-template-columns: repeat(4, 1fr); }
+}
+
+/* Reveal: honor reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal] { opacity: 1; transform: none; transition: none; }
+  .prompts .prompt:nth-child(n) { transition-delay: 0ms; }
+}

--- a/website/css/tokens.css
+++ b/website/css/tokens.css
@@ -1,0 +1,204 @@
+/* =============================================================================
+   Backcast Showcase — Design Tokens & Base Layer
+   Source of truth for the "Serif" editorial design system (vanilla HTML/CSS/JS).
+   Drop into the project as css/tokens.css and <link> it FIRST (before styles.css).
+
+   Fonts are NOT @imported here — load them via <link> in <head> for performance.
+   (See the page skeleton in design-system.md.)
+   ========================================================================== */
+
+:root {
+  /* ---- Color: monochrome canvas + single warm gold accent ---- */
+  --background: #FAFAF8;                   /* ivory canvas, warmer than pure white */
+  --foreground: #1A1A1A;                   /* rich black text (not pure #000)        */
+  --muted: #F5F3F0;                        /* secondary surfaces, slightly warmer    */
+  --muted-foreground: #6B6B6B;             /* secondary text, warm gray              */
+  --card: #FFFFFF;                         /* card surfaces — lift from ivory        */
+
+  --accent: #B8860B;                       /* burnished gold — links, highlights     */
+  --accent-secondary: #D4A84B;             /* lighter gold — hover/gradient          */
+  --accent-foreground: #FFFFFF;            /* text on accent backgrounds             */
+  --accent-muted: rgba(184, 134, 11, 0.06);/* featured-card tint (6%)               */
+
+  --border: #E8E4DF;                       /* warm gray rules, dividers, card borders*/
+  --border-hover: #D8D2CB;                 /* darker border on hover                 */
+  --input: #E8E4DF;                        /* input borders (matches --border)       */
+  --ring: #B8860B;                         /* focus ring (matches accent)            */
+
+  /* Surface alphas (over --background / --muted) */
+  --background-translucent: rgba(250, 250, 248, 0.85); /* sticky header frost */
+  --muted-50: rgba(245, 243, 240, 0.5);               /* card-hover tint      */
+
+  /* ---- Typography ---- */
+  --font-display: "Playfair Display", Georgia, "Times New Roman", serif;
+  --font-body: "Source Sans 3", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+
+  /* Type scale (rem; 1rem = 16px). Tailwind origin noted for traceability. */
+  --text-hero: 4.5rem;       /* 72px  text-7xl — Playfair, leading 1.1, tracking -0.02em */
+  --text-h2: 2.5rem;         /* 40px  text-4xl — section headlines, leading 1.2          */
+  --text-h3: 1.5rem;         /* 24px  text-2xl                                          */
+  --text-card-title: 1.25rem;/* 20px  text-xl  — Playfair semibold, leading 1.3          */
+  --text-body-lg: 1.125rem;  /* 18px  text-lg                                           */
+  --text-body: 1rem;         /* 16px  text-base — body, leading 1.75                    */
+  --text-nav: 0.875rem;      /* 14px  text-sm  — nav, medium, tracking 0.05em           */
+  --text-label: 0.75rem;     /* 12px  text-xs  — mono small-caps, tracking 0.15em       */
+
+  /* ---- Radii ---- */
+  --radius-md: 0.375rem;     /* 6px  — buttons, inputs                                  */
+  --radius-lg: 0.5rem;       /* 8px  — cards                                            */
+
+  /* ---- Shadows (restrained; rgba over rich-black 26,26,26) ---- */
+  --shadow-sm: 0 1px 2px rgba(26, 26, 26, 0.04);
+  --shadow-md: 0 4px 12px rgba(26, 26, 26, 0.06);
+  --shadow-lg: 0 8px 24px rgba(26, 26, 26, 0.08);
+  --shadow-accent: 0 8px 24px rgba(184, 134, 11, 0.18); /* accent-tinted hover lift */
+
+  /* ---- Spacing scale (0.25rem rhythm; Tailwind step noted) ---- */
+  --space-1: 0.25rem;  --space-2: 0.5rem;   --space-3: 0.75rem; --space-4: 1rem;
+  --space-6: 1.5rem;   --space-8: 2rem;     --space-10: 2.5rem; --space-12: 3rem;
+  --space-16: 4rem;    --space-20: 5rem;    --space-24: 6rem;
+  --space-32: 8rem;    --space-40: 10rem;   --space-44: 11rem;
+
+  /* ---- Layout ---- */
+  --container-narrow: 64rem; /* 1024px — max-w-5xl, reading comfort                  */
+  --container-wide: 80rem;   /* 1280px — max-w-7xl, wider grids                       */
+  --header-h: 4.5rem;        /* sticky header height — used for scroll-margin         */
+
+  /* ---- Motion ---- */
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --transition: 200ms var(--ease);
+  --transition-fast: 150ms var(--ease);
+
+  /* ---- Signature texture strength (tune to taste) ---- */
+  --texture-opacity: 0.035;  /* spec says "30% layer intent"; fractalNoise reads far
+                                stronger than a flat tint, so a low alpha is correct  */
+}
+
+/* ---- Reset ---- */
+*, *::before, *::after { box-sizing: border-box; }
+* { margin: 0; }
+html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+img, svg, video { display: block; max-width: 100%; }
+input, button, textarea, select { font: inherit; color: inherit; }
+
+/* Respect reduced-motion globally */
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ---- Body ---- */
+body {
+  background-color: var(--background);
+  color: var(--foreground);
+  font-family: var(--font-body);
+  font-size: var(--text-body);
+  line-height: 1.75;
+  letter-spacing: 0.01em;
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* ---- Base typography ---- */
+h1, h2, h3, h4 {
+  font-family: var(--font-display);
+  font-weight: 400;            /* Playfair reads best at normal weight */
+  line-height: 1.2;
+  color: var(--foreground);
+}
+h1 { font-size: var(--text-hero); line-height: 1.1; letter-spacing: -0.02em; }
+h2 { font-size: var(--text-h2); letter-spacing: -0.01em; }
+h3 { font-size: var(--text-card-title); font-weight: 600; line-height: 1.3; }
+
+p { line-height: 1.75; max-width: 65ch; }     /* comfortable measure for reading */
+a { color: var(--accent); text-decoration: none; transition: color var(--transition-fast); }
+a:hover { color: var(--accent-secondary); }
+strong { font-weight: 600; }
+
+/* ---- Selection ---- */
+::selection { background: var(--accent); color: var(--accent-foreground); }
+
+/* ---- Visible, accessible focus everywhere ---- */
+:where(a, button, input, textarea, select, summary, [tabindex]):focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-md);
+}
+
+/* ---- Utilities ---- */
+.small-caps {
+  font-family: var(--font-mono);
+  font-size: var(--text-label);
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.container {
+  width: 100%;
+  max-width: var(--container-narrow);
+  margin-inline: auto;
+  padding-inline: var(--space-6);
+}
+.container--wide { max-width: var(--container-wide); }
+
+.section { padding-block: var(--space-32); }     /* py-32 — paced, contemplative */
+.section--lg { padding-block: var(--space-44); } /* py-44 — premium breathing room  */
+
+.rule { height: 1px; background: var(--border); border: 0; width: 100%; }
+
+/* Scroll anchor offset so sticky header doesn't cover section tops */
+section[id] { scroll-margin-top: calc(var(--header-h) + var(--space-6)); }
+
+/* Skip link (a11y) — visible on focus */
+.skip-link {
+  position: absolute;
+  left: var(--space-4);
+  top: -100%;
+  z-index: 100;
+  background: var(--foreground);
+  color: var(--background);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  transition: top var(--transition-fast);
+}
+.skip-link:focus { top: var(--space-4); }
+
+/* ---- Signature: paper-texture overlay (print-like tactility) ---- */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  opacity: var(--texture-opacity);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+/* Keep real content above the texture layer */
+body > * { position: relative; z-index: 2; }
+
+/* ---- Signature: ambient glow (opt-in — add .has-glow to a section) ----
+   overflow:hidden clips the wide radial so it can't cause horizontal scroll
+   on narrow viewports (the glow is 60rem wide, centered). */
+.has-glow { position: relative; isolation: isolate; overflow: hidden; }
+.has-glow::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 60rem;
+  height: 60rem;
+  transform: translateX(-50%);
+  background: radial-gradient(circle, rgba(184, 134, 11, 0.03), transparent 70%);
+  filter: blur(40px);
+  z-index: -1;
+  pointer-events: none;
+}

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,288 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Backcast — A Time Machine for Project Governance</title>
+  <meta name="description" content="Backcast pairs multi-agent AI with a deterministic, fully-audited ledger. Build work breakdowns, book costs, run change orders, and revisit any moment in a project's history — by talking to it." />
+  <meta name="theme-color" content="#FAFAF8" />
+
+  <!-- Favicon: minimal serif mark (replace with a real asset/favicon.svg later) -->
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%23FAFAF8'/%3E%3Ctext x='16' y='24' font-family='Georgia,serif' font-size='22' font-weight='600' fill='%23B8860B' text-anchor='middle'%3EB%3C/text%3E%3C/svg%3E" />
+
+  <!-- Fonts: Playfair Display (display), Source Sans 3 (body), IBM Plex Mono (labels) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@500&family=Playfair+Display:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="css/tokens.css" />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header">
+    <div class="container container--wide site-header__inner">
+      <a class="wordmark" href="/">Backcast</a>
+
+      <button class="nav-toggle" data-nav-toggle aria-expanded="false" aria-controls="primary-nav" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+
+      <nav class="primary-nav" id="primary-nav" data-nav aria-label="Primary">
+        <a href="#features">Capabilities</a>
+        <a href="#action">In action</a>
+        <a href="#how">Under the hood</a>
+        <a class="btn btn--primary" href="https://app.backcast.duckdns.org" target="_blank" rel="noopener noreferrer">Live demo &rarr;</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <!-- HERO — the essentials only -->
+    <section class="section section--lg hero has-glow" data-reveal>
+      <div class="container hero__inner">
+        <div class="section-label section-label--center">
+          <span class="section-label__rule"></span>
+          <span class="small-caps section-label__text">Autonomous Project Governance</span>
+          <span class="section-label__rule"></span>
+        </div>
+        <h1 class="hero__title">A time machine for project governance.</h1>
+        <p class="lede">Multi-agent AI meets a deterministic, fully-audited ledger. Build work breakdowns, book costs, run change orders, and revisit any moment in a project&rsquo;s history &mdash; by talking to it.</p>
+        <div class="hero__cta">
+          <a class="btn btn--primary" href="https://app.backcast.duckdns.org" target="_blank" rel="noopener noreferrer">Try the live demo &rarr;</a>
+          <a class="btn btn--outline" href="#action">See it in action</a>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule" />
+
+    <!-- PILLARS — the differentiators at a glance -->
+    <section class="section pillars-section" data-reveal aria-label="What makes it different">
+      <div class="container container--wide">
+        <ul class="pillars">
+          <li class="pillar">
+            <h3 class="pillar__title">Time-travel ledger</h3>
+            <p class="pillar__body">Reconstruct the exact state of any project on any past date.</p>
+          </li>
+          <li class="pillar">
+            <h3 class="pillar__title">Deterministic guardrails</h3>
+            <p class="pillar__body">Agents use the same APIs, RBAC and audit trail as humans.</p>
+          </li>
+          <li class="pillar">
+            <h3 class="pillar__title">Multi-agent teams</h3>
+            <p class="pillar__body">Orchestrator&ndash;worker roles that critique their own work first.</p>
+          </li>
+          <li class="pillar">
+            <h3 class="pillar__title">MCP-native</h3>
+            <p class="pillar__body">Reach legacy ERPs, the web and custom skills beyond the core.</p>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <hr class="rule" />
+
+    <!-- THESIS — asymmetric, short -->
+    <section class="section benefits" id="thesis" data-reveal>
+      <div class="container container--wide benefits__grid">
+        <div class="benefits__lead">
+          <div class="section-label section-label--start">
+            <span class="section-label__rule"></span>
+            <span class="small-caps section-label__text">Why it&rsquo;s different</span>
+          </div>
+          <h2 class="benefits__title">Statistical AI. Deterministic governance. Finally, both.</h2>
+          <p>LLMs are brilliant at intent &mdash; and unreliable at structure. Left to parse work breakdowns or compute Earned Value on token probabilities, they drift. Backcast doesn&rsquo;t let them.</p>
+        </div>
+        <ul class="benefits__points">
+          <li class="benefit"><span class="benefit__mark">&mdash;</span><span>The AI proposes the intent.</span></li>
+          <li class="benefit"><span class="benefit__mark">&mdash;</span><span>A rigid application layer guarantees the structure.</span></li>
+          <li class="benefit"><span class="benefit__mark">&mdash;</span><span>Every action audited, every time.</span></li>
+        </ul>
+      </div>
+    </section>
+
+    <hr class="rule" />
+
+    <!-- CAPABILITIES — scannable cards -->
+    <section class="section features" id="features" data-reveal>
+      <div class="container container--wide">
+        <div class="section-label section-label--start">
+          <span class="section-label__rule"></span>
+          <span class="small-caps section-label__text">What it does</span>
+        </div>
+        <h2 class="features__title">From a sentence to a structured project.</h2>
+
+        <ul class="features__grid">
+          <li class="card card--hover">
+            <span class="card__index small-caps">01</span>
+            <h3 class="card__title">Autonomous WBS generation</h3>
+            <p class="card__body">Turn a statement of work into a complete tree of tasks, control accounts and milestones &mdash; reviewed before anything is committed.</p>
+          </li>
+          <li class="card card--hover">
+            <span class="card__index small-caps">02</span>
+            <h3 class="card__title">Intelligent change orders</h3>
+            <p class="card__body">Analyze downstream impact across budget, schedule, revenue and EVM &mdash; then draft a compliant change order for approval.</p>
+          </li>
+          <li class="card card--hover">
+            <span class="card__index small-caps">03</span>
+            <h3 class="card__title">Semantic EVM</h3>
+            <p class="card__body">CPI, SPI, EAC and variance translated into plain-language strategic readouts &mdash; not just dashboards.</p>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <hr class="rule" />
+
+    <!-- IN ACTION — progressive disclosure via scroll-revealed chat prompts -->
+    <section class="section action" id="action" data-reveal>
+      <div class="container">
+        <div class="section-label section-label--start">
+          <span class="section-label__rule"></span>
+          <span class="small-caps section-label__text">See it in action</span>
+        </div>
+        <h2 class="action__title">Just talk to your project.</h2>
+        <p class="action__intro">Your assistant already knows your WBS conventions, approval thresholds and reporting standards. Here&rsquo;s what that looks like &mdash; one capability at a time.</p>
+
+        <div class="prompts">
+          <figure class="prompt" data-reveal>
+            <p class="prompt__command"><span class="small-caps prompt__label">You say</span> &ldquo;Create the &lsquo;Renovation HQ 2027&rsquo; project with a 3-level WBS, &euro;8.4M budget, starting in March.&rdquo;</p>
+            <p class="prompt__outcome">The AI builds the entire structure &mdash; work breakdown elements, control accounts, work packages, cost elements &mdash; and you review before anything is committed.</p>
+          </figure>
+
+          <figure class="prompt" data-reveal>
+            <p class="prompt__command"><span class="small-caps prompt__label">You say</span> &ldquo;Record the &euro;142k invoice from supplier Alpha on the HVAC cost element.&rdquo;</p>
+            <p class="prompt__outcome">Actuals are booked against the right cost element, EVM metrics recalculate instantly, and the audit trail captures who recorded what, when and why.</p>
+          </figure>
+
+          <figure class="prompt" data-reveal>
+            <p class="prompt__command"><span class="small-caps prompt__label">You say</span> &ldquo;Open a change order shifting Electrical by 3 months and raising Mechanical by 18%. Show EAC and TCPI impact.&rdquo;</p>
+            <p class="prompt__outcome">A branch is created. The AI runs a four-dimension impact analysis &mdash; budget, schedule, revenue, EVM &mdash; and presents findings in plain language so the Change Control Board decides faster.</p>
+          </figure>
+
+          <figure class="prompt" data-reveal>
+            <p class="prompt__command"><span class="small-caps prompt__label">You say</span> &ldquo;Compare current status with the project state from 45 days ago.&rdquo;</p>
+            <p class="prompt__outcome">The time machine reconstructs the project as it existed 45 days ago &mdash; CPI, SPI, EAC and every other metric at that point in time, with full variance context explained.</p>
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule" />
+
+    <!-- UNDER THE HOOD — depth on demand, behind accordions -->
+    <section class="section how" id="how" data-reveal>
+      <div class="container">
+        <div class="section-label section-label--start">
+          <span class="section-label__rule"></span>
+          <span class="small-caps section-label__text">Under the hood</span>
+        </div>
+        <h2 class="how__title">Depth, on demand.</h2>
+        <p class="how__intro">The essentials above. The architecture below &mdash; open only what you need.</p>
+
+        <div class="accordions">
+          <div class="accordion" data-accordion>
+            <button class="accordion__trigger" data-accordion-trigger aria-expanded="false" aria-controls="acc-ledger">The Temporal Ledger</button>
+            <div class="accordion__panel" id="acc-ledger" data-accordion-panel hidden>
+              <p>Every change to a task, baseline or cost is captured as a historical delta. Reconstruct the full state of a project at any point in time &mdash; the archaeological layers, not just today&rsquo;s surface.</p>
+            </div>
+          </div>
+
+          <div class="accordion" data-accordion>
+            <button class="accordion__trigger" data-accordion-trigger aria-expanded="false" aria-controls="acc-guard">Grounded application security</button>
+            <div class="accordion__panel" id="acc-guard" data-accordion-panel hidden>
+              <p>No raw database access. Agents act through the same Application APIs as human users, passing identical RBAC, constraints and audit. The LLM suggests the intent; the application layer guarantees the structure.</p>
+            </div>
+          </div>
+
+          <div class="accordion" data-accordion>
+            <button class="accordion__trigger" data-accordion-trigger aria-expanded="false" aria-controls="acc-harness">Configurable agent harness</button>
+            <div class="accordion__panel" id="acc-harness" data-accordion-panel hidden>
+              <p>Declarative manifests define roles, specialized prompts, permissions and tool mappings &mdash; applying Orchestrator&ndash;Workers and Reflection patterns directly to project controls.</p>
+            </div>
+          </div>
+
+          <div class="accordion" data-accordion>
+            <button class="accordion__trigger" data-accordion-trigger aria-expanded="false" aria-controls="acc-mcp">Extensibility via MCP</button>
+            <div class="accordion__panel" id="acc-mcp" data-accordion-panel hidden>
+              <p>Plug in legacy ERPs, web search and custom skills through the Model Context Protocol. Agents discover capabilities dynamically, based on their manifest.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule" />
+
+    <!-- GET STARTED — minimal -->
+    <section class="section start" id="start" data-reveal>
+      <div class="container">
+        <div class="section-label section-label--start">
+          <span class="section-label__rule"></span>
+          <span class="small-caps section-label__text">Get started</span>
+        </div>
+        <h2 class="how__title">Run it yourself.</h2>
+        <p class="how__intro">Docker is the recommended path. Clone, configure, bring it up.</p>
+
+        <pre class="code"><code>git clone https://github.com/ogghst/backcast.git &amp;&amp; cd backcast
+docker network create traefik-public
+cd deploy &amp;&amp; cp .env.production.example .env.production
+docker compose --env-file .env.production up -d --build</code></pre>
+
+        <div class="start__links">
+          <a class="btn btn--ghost" href="https://github.com/ogghst/backcast/blob/main/docs/05-user-guide/docker-deployment-guide.md" target="_blank" rel="noopener noreferrer">Full deployment guide &rarr;</a>
+          <a class="btn btn--ghost" href="https://github.com/ogghst/backcast/blob/main/docs/00-meta/onboarding.md" target="_blank" rel="noopener noreferrer">Local dev &amp; onboarding &rarr;</a>
+        </div>
+      </div>
+    </section>
+
+    <hr class="rule" />
+
+    <!-- LIVE DEMO CTA -->
+    <section class="section section--lg cta has-glow" id="demo" data-reveal>
+      <div class="container cta__inner">
+        <div class="section-label section-label--center">
+          <span class="section-label__rule"></span>
+          <span class="small-caps section-label__text">Try it now</span>
+          <span class="section-label__rule"></span>
+        </div>
+        <h2 class="cta__title">The demo is built to be tested hard.</h2>
+        <p class="lede">Jump in, create projects, open change orders, travel through time. Shared credentials below.</p>
+
+        <dl class="creds">
+          <div class="cred">
+            <dt class="small-caps cred__label">Email</dt>
+            <dd class="cred__value">admin@backcast.org</dd>
+          </div>
+          <div class="cred">
+            <dt class="small-caps cred__label">Password</dt>
+            <dd class="cred__value">adminadmin</dd>
+          </div>
+        </dl>
+
+        <div class="hero__cta">
+          <a class="btn btn--primary" href="https://app.backcast.duckdns.org" target="_blank" rel="noopener noreferrer">Open the live demo &rarr;</a>
+          <a class="btn btn--ghost" href="https://github.com/ogghst/backcast" target="_blank" rel="noopener noreferrer">Read the source &rarr;</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container container--wide site-footer__inner">
+      <a class="wordmark" href="/">Backcast</a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="https://github.com/ogghst/backcast" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://app.backcast.duckdns.org" target="_blank" rel="noopener noreferrer">Live demo</a>
+        <a href="#start">Get started</a>
+        <a href="https://github.com/ogghst/backcast/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>
+      </nav>
+      <p class="small-caps">&copy; <span data-year></span> Backcast &middot; An autonomous governance platform</p>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/website/js/main.js
+++ b/website/js/main.js
@@ -1,0 +1,60 @@
+/* =============================================================================
+   Backcast Showcase — interactions (vanilla, dependency-free)
+   Pairs with markup in index.html and components in css/styles.css.
+   ========================================================================== */
+(() => {
+  "use strict";
+
+  /* --- Reveal on scroll (progressive enhancement; no-op if unsupported) --- */
+  const revealEls = document.querySelectorAll("[data-reveal]");
+  if (revealEls.length && "IntersectionObserver" in window) {
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("is-visible");
+            io.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: 0.12, rootMargin: "0px 0px -10% 0px" }
+    );
+    revealEls.forEach((el) => io.observe(el));
+  } else {
+    revealEls.forEach((el) => el.classList.add("is-visible"));
+  }
+
+  /* --- Mobile navigation toggle --- */
+  const navToggle = document.querySelector("[data-nav-toggle]");
+  const nav = document.querySelector("[data-nav]");
+  if (navToggle && nav) {
+    const setOpen = (open) => {
+      nav.classList.toggle("is-open", open);
+      navToggle.setAttribute("aria-expanded", String(open));
+    };
+    navToggle.addEventListener("click", () =>
+      setOpen(!nav.classList.contains("is-open"))
+    );
+    // Close the panel after following a link (mobile)
+    nav.querySelectorAll("a").forEach((a) =>
+      a.addEventListener("click", () => setOpen(false))
+    );
+  }
+
+  /* --- FAQ accordion (ready for when FAQ sections are added) --- */
+  document.querySelectorAll("[data-accordion-trigger]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const item = btn.closest("[data-accordion]");
+      const panel = item ? item.querySelector("[data-accordion-panel]") : null;
+      const open = btn.getAttribute("aria-expanded") === "true";
+      btn.setAttribute("aria-expanded", String(!open));
+      if (item) item.classList.toggle("is-open", !open);
+      if (panel) panel.hidden = open;
+    });
+  });
+
+  /* --- Footer year --- */
+  document.querySelectorAll("[data-year]").forEach((el) => {
+    el.textContent = String(new Date().getFullYear());
+  });
+})();


### PR DESCRIPTION
## Summary

Adds the Backcast showcase / marketing site under `website/` — a **pure client-side** site (HTML + CSS + JS, no framework, no build step) presenting the product in the **"Serif" editorial design system** (Playfair Display / Source Sans 3 / IBM Plex Mono on an ivory canvas with a burnished-gold accent).

## Contents
- `index.html` — landing page (*"A time machine for project governance."*)
- `css/tokens.css`, `css/styles.css` — design-system tokens + styles
- `js/main.js` — interactions

## Notes
- **Independent of the application** — no backend or frontend (React) app changes; the app and the showcase site live side by side.
- **No build/install required** — open `website/index.html` directly in a browser.
- Kept on its own branch/PR (separate from the global-dashboard-widgets work in #107).

🤖 Generated with [Claude Code](https://claude.com/claude-code)