### PR TITLE
release: trunk integration — Portfolio Gantt, dashboard reactivity, EVM/COQ fixes, PanelCard UI, marketing site

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,6 +30,7 @@ Dockerfile*
 # Deploy (production configs)
 deploy
 !deploy/frontend/nginx.conf
+!deploy/website/nginx.conf
 !deploy/scripts/entrypoint-frontend.sh
 !deploy/scripts/entrypoint-backend.sh
 

--- a/backend/app/api/routes/change_orders.py
+++ b/backend/app/api/routes/change_orders.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
@@ -31,6 +31,18 @@ from app.services.impact_analysis_service import ImpactAnalysisService
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _ensure_aware_utc(dt: datetime) -> datetime:
+    """Coerce an offset-naive datetime to UTC.
+
+    FastAPI parses ``datetime`` query params as offset-naive when the client
+    omits a tz suffix, but downstream comparisons (e.g. ``_get_aging_items``)
+    subtract offset-aware ``timestamptz`` values from DB rows, which raises
+    ``TypeError: can't subtract offset-naive and offset-aware datetimes``.
+    Naive inputs are assumed to be UTC (the storage/compare zone).
+    """
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
 
 
 def get_change_order_service(
@@ -80,10 +92,12 @@ async def get_portfolio_change_order_stats(
 
     Requires ``portfolio-read`` permission.
     """
-    from datetime import UTC
-
     if as_of is None:
         as_of = datetime.now(UTC)
+    else:
+        # FastAPI parses query params naive when no tz suffix is supplied;
+        # coerce to UTC before subtracting offset-aware ``changed_at`` rows.
+        as_of = _ensure_aware_utc(as_of)
 
     # Resolve the caller's accessible project set (RBAC membership scoping).
     from app.core.rbac_unified import (
@@ -138,11 +152,11 @@ async def get_change_order_stats(
 
     Requires change-order-read permission.
     """
-    from datetime import UTC
-
-    # Default to current time if as_of is not provided
+    # Default to current time if as_of is not provided; coerce naive -> UTC.
     if as_of is None:
         as_of = datetime.now(UTC)
+    else:
+        as_of = _ensure_aware_utc(as_of)
 
     try:
         return await service.get_change_order_stats(
@@ -216,11 +230,11 @@ async def read_change_orders(
     skip = (page - 1) * per_page
 
     try:
-        # Default to current time if as_of is not provided
+        # Default to current time if as_of is not provided; coerce naive -> UTC.
         if as_of is None:
-            from datetime import UTC
-
-            as_of = datetime.now(tz=UTC)
+            as_of = datetime.now(UTC)
+        else:
+            as_of = _ensure_aware_utc(as_of)
 
         # Get change orders for the project
         change_orders, total = await service.get_change_orders(
@@ -417,11 +431,11 @@ async def read_change_order(
 
     Requires read permission.
     """
-    # Default to current time if as_of is not provided
+    # Default to current time if as_of is not provided; coerce naive -> UTC.
     if as_of is None:
-        from datetime import UTC
-
-        as_of = datetime.now(tz=UTC)
+        as_of = datetime.now(UTC)
+    else:
+        as_of = _ensure_aware_utc(as_of)
 
     if as_of:
         # Time travel query

--- a/backend/app/api/routes/evm.py
+++ b/backend/app/api/routes/evm.py
@@ -260,7 +260,11 @@ async def get_evm_metrics(
 
         # Handle WBE and Project entity types (batch aggregation)
         elif entity_type in (EntityType.WBS_ELEMENT, EntityType.PROJECT):
-            # Validate entity exists before calculating metrics
+            # Validate entity exists before calculating metrics. If the entity
+            # exists in principle but has no version valid as of control_date
+            # (e.g. the project version's valid_time starts after control_date),
+            # return an empty metrics response with a warning rather than 404 --
+            # there is simply no data yet, which is not an error condition.
             if entity_type == EntityType.WBS_ELEMENT:
                 wbe = await service.wbs_service.get_as_of(
                     entity_id=entity_id,
@@ -269,7 +273,29 @@ async def get_evm_metrics(
                     branch_mode=branch_mode,
                 )
                 if wbe is None:
-                    raise ValueError(f"WBE with ID {entity_id} not found")
+                    return EVMMetricsResponse(  # type: ignore[return-value]
+                        entity_type=entity_type,
+                        entity_id=entity_id,
+                        bac=Decimal("0"),
+                        pv=Decimal("0"),
+                        ac=Decimal("0"),
+                        ev=Decimal("0"),
+                        cv=Decimal("0"),
+                        sv=Decimal("0"),
+                        cpi=None,
+                        spi=None,
+                        eac=None,
+                        vac=None,
+                        etc=None,
+                        tcpi=None,
+                        control_date=control_date,
+                        branch=branch,
+                        branch_mode=branch_mode,
+                        progress_percentage=None,
+                        warning=(
+                            f"No 'wbe' data available as of {control_date.date()}"
+                        ),
+                    )
             elif entity_type == EntityType.PROJECT:
                 project = await service.project_service.get_as_of(
                     entity_id=entity_id,
@@ -278,7 +304,29 @@ async def get_evm_metrics(
                     branch_mode=branch_mode,
                 )
                 if project is None:
-                    raise ValueError(f"Project with ID {entity_id} not found")
+                    return EVMMetricsResponse(  # type: ignore[return-value]
+                        entity_type=entity_type,
+                        entity_id=entity_id,
+                        bac=Decimal("0"),
+                        pv=Decimal("0"),
+                        ac=Decimal("0"),
+                        ev=Decimal("0"),
+                        cv=Decimal("0"),
+                        sv=Decimal("0"),
+                        cpi=None,
+                        spi=None,
+                        eac=None,
+                        vac=None,
+                        etc=None,
+                        tcpi=None,
+                        control_date=control_date,
+                        branch=branch,
+                        branch_mode=branch_mode,
+                        progress_percentage=None,
+                        warning=(
+                            f"No 'project' data available as of {control_date.date()}"
+                        ),
+                    )
 
             # Use batch calculation for aggregation
             response = await service.calculate_evm_metrics_batch(

--- a/backend/app/models/schemas/evm.py
+++ b/backend/app/models/schemas/evm.py
@@ -336,6 +336,12 @@ class PortfolioProjectMetrics(BaseModel):
             "history exists."
         ),
     )
+    start_date: datetime | None = Field(
+        None, description="Project planned start date (null when unset)."
+    )
+    end_date: datetime | None = Field(
+        None, description="Project planned end date (null when unset)."
+    )
 
 
 class PortfolioEVMResponse(BaseModel):

--- a/backend/app/services/cost_event_service.py
+++ b/backend/app/services/cost_event_service.py
@@ -308,10 +308,36 @@ class CostEventService(TemporalService[CostEvent]):  # type: ignore[type-var,unu
         """
         quality_ids = await self._get_quality_event_type_ids()
 
-        cr_filters_current = [
-            func.upper(CostRegistration.valid_time).is_(None),
-            CostRegistration.deleted_at.is_(None),
-        ]
+        # Apply as_of time-travel when requested. CostEvent is filtered via this
+        # service's bitemporal helper (bound to CostEvent); CostRegistration is a
+        # different entity, so we reuse CostRegistrationService's helper (bound to
+        # CostRegistration) -- exactly how EVMService computes AC. When as_of is
+        # None we keep the original current-version filter. See get_summary /
+        # cr_service.get_total_for_work_package for the canonical pattern.
+        if as_of is not None:
+            from app.services.cost_registration_service import CostRegistrationService
+
+            cr_service = CostRegistrationService(self.session)
+
+            def _apply_cr(stmt: Any) -> Any:
+                return cr_service._apply_bitemporal_filter(stmt, as_of)  # noqa: SLF001
+
+            def _apply_event(stmt: Any) -> Any:
+                return self._apply_bitemporal_filter(stmt, as_of)
+
+        else:
+            cr_filters_current = [
+                func.upper(CostRegistration.valid_time).is_(None),
+                CostRegistration.deleted_at.is_(None),
+            ]
+
+            def _apply_cr(stmt: Any) -> Any:
+                return stmt.where(*cr_filters_current)
+
+            # Original behavior: as_of=None never applied a bitemporal filter to
+            # CostEvent (only CostRegistration). Keep it a no-op here.
+            def _apply_event(stmt: Any) -> Any:
+                return stmt
 
         # 1. Total COQ: sum of CR.amount where cost_event_id IS NOT NULL and event type is quality
         total_coq_stmt = (
@@ -324,9 +350,10 @@ class CostEventService(TemporalService[CostEvent]):  # type: ignore[type-var,unu
                 CostEvent.project_id == project_id,
                 CostEvent.cost_event_type_id.in_(quality_ids),
                 CostRegistration.cost_event_id.isnot(None),
-                *cr_filters_current,
             )
         )
+        total_coq_stmt = _apply_cr(total_coq_stmt)
+        total_coq_stmt = _apply_event(total_coq_stmt)
         total_coq_result = await self.session.execute(total_coq_stmt)
         total_coq = Decimal(str(total_coq_result.scalar_one()))
 
@@ -342,9 +369,10 @@ class CostEventService(TemporalService[CostEvent]):  # type: ignore[type-var,unu
                 CostEvent.cost_event_type_id.in_(quality_ids),
                 CostEvent.coq_category.in_(["internal_failure", "external_failure"]),
                 CostRegistration.cost_event_id.isnot(None),
-                *cr_filters_current,
             )
         )
+        cpq_stmt = _apply_cr(cpq_stmt)
+        cpq_stmt = _apply_event(cpq_stmt)
         cpq_result = await self.session.execute(cpq_stmt)
         cpq = Decimal(str(cpq_result.scalar_one()))
 
@@ -369,9 +397,9 @@ class CostEventService(TemporalService[CostEvent]):  # type: ignore[type-var,unu
             )
             .where(
                 WBSElement.project_id == project_id,
-                *cr_filters_current,
             )
         )
+        total_ac_stmt = _apply_cr(total_ac_stmt)
         total_ac_result = await self.session.execute(total_ac_stmt)
         total_ac = Decimal(str(total_ac_result.scalar_one()))
 

--- a/backend/app/services/evm_service.py
+++ b/backend/app/services/evm_service.py
@@ -1445,7 +1445,12 @@ class EVMService:
         )
 
         # Only projects that actually have a current version contribute.
-        live_project_ids = [pid for pid in project_ids if pid in projects_map]
+        # Dedup preserving order: RBAC ``accessible_project_ids`` can repeat a
+        # project for users with multiple grants, which would otherwise yield
+        # duplicate ``PortfolioProjectMetrics`` rows (mirrors line 1322).
+        live_project_ids = list(
+            dict.fromkeys(pid for pid in project_ids if pid in projects_map)
+        )
         for missing_pid in set(project_ids) - set(live_project_ids):
             logger.warning(
                 "Portfolio: project %s not found as_of %s; skipping",

--- a/backend/app/services/evm_service.py
+++ b/backend/app/services/evm_service.py
@@ -1563,6 +1563,8 @@ class EVMService:
                     customer_id=project.customer_id,
                     at_risk=at_risk,
                     delta_eac=delta_eac_b,
+                    start_date=project.start_date,
+                    end_date=project.end_date,
                 )
             )
 

--- a/backend/app/services/system_admin_service.py
+++ b/backend/app/services/system_admin_service.py
@@ -235,8 +235,33 @@ class SystemAdminService:
         result["mcp_servers"] = mcp_servers
 
         # --- Change order workflow ---
-        co_config_result = await self.session.execute(select(ChangeOrderWorkflowConfig))
-        co_config = co_config_result.scalar_one_or_none()
+        # Global config only — per-project overrides (project_id != NULL)
+        # are not part of the single-config system_config dump/reseed format.
+        global_configs_result = await self.session.execute(
+            select(ChangeOrderWorkflowConfig)
+            .where(ChangeOrderWorkflowConfig.project_id.is_(None))
+            .order_by(ChangeOrderWorkflowConfig.created_at)
+        )
+        global_configs = list(global_configs_result.scalars().all())
+        co_config = None
+        if global_configs:
+            # Prefer the config that actually has child rules; an empty
+            # duplicate global can exist alongside the populated seed config.
+            co_config = next(
+                (
+                    c
+                    for c in global_configs
+                    if c.impact_levels or c.approval_rules or c.sla_rules
+                ),
+                global_configs[0],
+            )
+            if len(global_configs) > 1:
+                logger.warning(
+                    "Multiple global change-order workflow configs found (%d); "
+                    "exporting %s",
+                    len(global_configs),
+                    co_config.id,
+                )
         if co_config is not None:
             config_dict = _model_to_dict(
                 co_config, exclude={"created_at", "updated_at"}

--- a/backend/app/services/wbs_element_service.py
+++ b/backend/app/services/wbs_element_service.py
@@ -862,10 +862,20 @@ class WBSElementService(BranchableService[WBSElement]):  # type: ignore[type-var
     async def _get_descendants_merged(
         self, parent_wbe_id: UUID, branch: str
     ) -> list[UUID]:
-        """Get descendant WBS Element IDs for MERGED mode on non-main branch."""
+        """Get descendant WBS Element IDs for MERGED mode on non-main branch.
+
+        PostgreSQL forbids ORDER BY (and therefore DISTINCT ON, which requires
+        it) in the arms of a recursive CTE. We therefore carry ``branch`` and
+        ``depth`` through the recursion and perform the prefer-current-branch
+        dedup ONCE in the final outer SELECT, where DISTINCT ON ... ORDER BY is
+        legal. The recursive arms only collect candidate rows from both the
+        current branch and main, excluding a main row when that wbs_element_id
+        is soft-deleted on the current branch.
+        """
         raw_sql = text("""
             WITH RECURSIVE wbs_descendants AS (
-                SELECT DISTINCT ON (wbs_element_id) wbs_element_id, 1 as depth
+                -- anchor: direct children of the parent (both branches)
+                SELECT wbs_element_id, branch, 1 AS depth
                 FROM wbs_elements
                 WHERE parent_wbs_element_id = :parent_wbe_id
                     AND branch IN (:current_branch, 'main')
@@ -879,31 +889,32 @@ class WBSElementService(BranchableService[WBSElement]):  # type: ignore[type-var
                               AND w.deleted_at IS NOT NULL
                         )
                     )
-                ORDER BY wbs_element_id, CASE WHEN branch = :current_branch THEN 0 ELSE 1 END
 
                 UNION ALL
 
-                SELECT child.wbs_element_id, wd.depth + 1
+                -- recursive: children of each descendant (both branches)
+                SELECT child.wbs_element_id, child.branch, wd.depth + 1
                 FROM wbs_descendants wd
-                INNER JOIN LATERAL (
-                    SELECT DISTINCT ON (wbs_element_id) wbs_element_id
-                    FROM wbs_elements w
-                    WHERE w.parent_wbs_element_id = wd.wbs_element_id
-                        AND branch IN (:current_branch, 'main')
-                        AND w.deleted_at IS NULL
-                        AND upper(valid_time) IS NULL
-                        AND NOT (
-                            branch = 'main'
-                            AND wbs_element_id IN (
-                                SELECT ww.wbs_element_id FROM wbs_elements ww
-                                WHERE ww.branch = :current_branch
-                                  AND ww.deleted_at IS NOT NULL
-                            )
-                        )
-                    ORDER BY wbs_element_id, CASE WHEN branch = :current_branch THEN 0 ELSE 1 END
-                ) child ON true
+                JOIN wbs_elements child
+                  ON child.parent_wbs_element_id = wd.wbs_element_id
+                 AND child.branch IN (:current_branch, 'main')
+                 AND child.deleted_at IS NULL
+                 AND upper(child.valid_time) IS NULL
+                 AND NOT (
+                     child.branch = 'main'
+                     AND child.wbs_element_id IN (
+                         SELECT ww.wbs_element_id FROM wbs_elements ww
+                         WHERE ww.branch = :current_branch
+                           AND ww.deleted_at IS NOT NULL
+                     )
+                 )
             )
-            SELECT wbs_element_id FROM wbs_descendants ORDER BY depth ASC
+            -- Dedup prefer-current-branch ONCE here (legal in outer SELECT).
+            SELECT DISTINCT ON (wbs_element_id) wbs_element_id
+            FROM wbs_descendants
+            ORDER BY wbs_element_id,
+                     CASE WHEN branch = :current_branch THEN 0 ELSE 1 END,
+                     depth ASC
         """)
 
         result = await self.session.execute(

--- a/backend/tests/api/routes/test_evm.py
+++ b/backend/tests/api/routes/test_evm.py
@@ -92,3 +92,35 @@ async def test_evm_wbs_element_level(
     data = response.json()
     assert "bac" in data
     assert data["entity_type"] == "wbs_element"
+
+
+@pytest.mark.asyncio
+async def test_evm_project_control_date_before_first_version_returns_200(
+    client: AsyncClient,
+    db: AsyncSession,
+    actor_id: UUID,
+) -> None:
+    """F3: control_date before the project's first valid_time returns 200.
+
+    The project exists but has no version valid as of the past control_date.
+    Previously this raised ValueError -> HTTP 404 (error storm). It must now
+    return 200 with zeroed metrics and a non-empty warning.
+    """
+    h = await create_full_hierarchy(db, actor_id)
+    await db.commit()
+
+    # control_date well before the project version's valid_time lower bound.
+    response = await client.get(
+        f"{PREFIX}/project/{h['project'].project_id}/metrics"
+        "?control_date=2020-01-01T00:00:00Z"
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["entity_type"] == "project"
+    assert float(data["bac"]) == 0.0
+    assert float(data["ac"]) == 0.0
+    assert float(data["ev"]) == 0.0
+    assert data["cpi"] is None
+    assert data["spi"] is None
+    assert data["warning"] is not None
+    assert "2020-01-01" in data["warning"]

--- a/backend/tests/api/routes/test_portfolio.py
+++ b/backend/tests/api/routes/test_portfolio.py
@@ -302,6 +302,45 @@ async def test_portfolio_evm_multi_currency_rollup(
     assert usd_row.bac == pytest.approx(float(Decimal(str(usd_metrics.bac)) * usd_rate))
 
 
+@pytest.mark.asyncio
+async def test_portfolio_evm_rows_carry_project_dates(
+    db: AsyncSession,
+    actor_id: UUID,
+) -> None:
+    """Each portfolio breakdown row carries the project's start/end_date.
+
+    A project with explicit dates surfaces them verbatim; a project with no
+    dates (the default factory) surfaces None. Required for the portfolio
+    Gantt widget to render one bar per project.
+    """
+    # Project with explicit planned dates.
+    start = datetime(2026, 1, 15, tzinfo=UTC)
+    end = datetime(2026, 9, 30, tzinfo=UTC)
+    dated = await create_test_project(
+        db, actor_id, start_date=start, end_date=end
+    )
+
+    # Project with no dates (factory default) — null case.
+    bare = await create_test_project(db, actor_id)
+
+    control_date = datetime.now(tz=UTC)
+    evm = EVMService(db)
+    portfolio = await evm.calculate_portfolio_evm(
+        project_ids=[dated.project_id, bare.project_id],
+        control_date=control_date,
+        branch="main",
+        branch_mode=BranchMode.MERGED,
+    )
+
+    dated_row = next(p for p in portfolio.projects if p.project_id == dated.project_id)
+    bare_row = next(p for p in portfolio.projects if p.project_id == bare.project_id)
+
+    assert dated_row.start_date == start
+    assert dated_row.end_date == end
+    assert bare_row.start_date is None
+    assert bare_row.end_date is None
+
+
 # ---------------------------------------------------------------------------
 # convert_to_base (load-bearing for the production portfolio-EVM path).
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/routes/test_portfolio.py
+++ b/backend/tests/api/routes/test_portfolio.py
@@ -181,6 +181,49 @@ async def test_portfolio_at_risk_subset_is_spi_below_threshold(
 
 
 @pytest.mark.asyncio
+async def test_portfolio_evm_dedups_duplicate_project_ids(
+    db: AsyncSession,
+    actor_id: UUID,
+) -> None:
+    """Duplicate ``project_ids`` (RBAC returns duplicates for users with
+    multiple grants) must NOT yield duplicate ``PortfolioProjectMetrics`` rows.
+
+    Regression for the React duplicate-key warning where /evm/portfolio returned
+    1346 items vs 1276 distinct project_ids. ``calculate_portfolio_evm`` dedups
+    ``live_project_ids`` (mirroring ``_get_projects_as_of_batch`` line 1322).
+    """
+    h = await create_full_hierarchy(db, actor_id)
+    project_id = h["project"].project_id
+    await create_test_cost_registration(
+        db, actor_id, h["ce"].cost_element_id, amount=Decimal("5000")
+    )
+    await create_test_progress_entry(
+        db, actor_id, h["wp"].work_package_id, progress_percentage=Decimal("10.00")
+    )
+    await db.commit()
+
+    evm = EVMService(db)
+    # Pass the SAME project_id multiple times — RBAC duplicate-grant shape.
+    portfolio = await evm.calculate_portfolio_evm(
+        project_ids=[project_id, project_id, project_id],
+        control_date=datetime.now(tz=UTC),
+        branch="main",
+        branch_mode=BranchMode.MERGED,
+    )
+
+    project_ids_returned = [p.project_id for p in portfolio.projects]
+    assert len(project_ids_returned) == len(set(project_ids_returned)), (
+        f"duplicate project_ids in portfolio.projects: {project_ids_returned}"
+    )
+    # Exactly one row for the single live project.
+    assert len(portfolio.projects) == 1
+
+    # The at-risk subset must likewise carry no duplicates.
+    at_risk_ids = [p.project_id for p in portfolio.at_risk_projects]
+    assert len(at_risk_ids) == len(set(at_risk_ids))
+
+
+@pytest.mark.asyncio
 async def test_portfolio_evm_multi_currency_rollup(
     db: AsyncSession,
     actor_id: UUID,
@@ -517,3 +560,39 @@ async def test_portfolio_stats_route_membership_scoped(
         project_id=project_id
     )
     assert data["total_count"] >= per_project.total_count
+
+
+@pytest.mark.asyncio
+async def test_portfolio_stats_naive_as_of_does_not_500(
+    client: AsyncClient,
+    db: AsyncSession,
+    actor_id: UUID,
+) -> None:
+    """A user-picked control date arrives as an offset-NAIVE datetime query
+    param (no tz suffix); the route must coerce it to UTC and return 200, not
+    crash with "can't subtract offset-naive and offset-aware datetimes" inside
+    ``_get_aging_items`` (``as_of - row.changed_at`` where ``changed_at`` is a
+    timestamptz). Regression for the portfolio-stats 500.
+    """
+    h = await create_full_hierarchy(db, actor_id)
+    project_id = h["project"].project_id
+    await db.commit()
+
+    # Explicit naive as_of (no tz suffix) — the exact FE controlDate shape.
+    response = await client.get(
+        "/change-orders/portfolio-stats",
+        params={"as_of": "2026-06-15T00:00:00"},
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert "total_count" in data
+    assert "aging_threshold_days" in data
+
+    # Same regression against the project-scoped /stats route (same latent bug
+    # via the shared ``_get_aging_items`` subtraction path).
+    stats_response = await client.get(
+        "/change-orders/stats",
+        params={"project_id": str(project_id), "as_of": "2026-06-15T00:00:00"},
+    )
+    assert stats_response.status_code == 200, stats_response.text
+    assert "total_count" in stats_response.json()

--- a/backend/tests/services/test_cost_event_service.py
+++ b/backend/tests/services/test_cost_event_service.py
@@ -527,6 +527,38 @@ async def test_get_coq_metrics_with_actual_costs(
 
 
 @pytest.mark.asyncio
+async def test_get_coq_metrics_as_of_filters_registrations(
+    db: AsyncSession, actor_id: UUID, service: CostEventService
+) -> None:
+    """F4: get_coq_metrics(as_of=past) must apply as_of to all three aggregates.
+
+    Previously `as_of` was accepted but ignored: total_coq/cpq/total_ac were
+    always computed from the current version. With a past as_of predating the
+    cost registration's valid_time, the registration must be excluded, so
+    total_ac decreases relative to the as_of=None (current) call.
+    """
+    data = await _setup_event_with_registration(
+        db,
+        actor_id,
+        coq_category="internal_failure",
+        registration_amount=Decimal("7000"),
+    )
+
+    # Current view: registration counted.
+    current = await service.get_coq_metrics(data["project"].project_id)
+    assert current.total_ac > Decimal("0")
+    assert current.total_coq == Decimal("7000")
+    assert current.cpq == Decimal("7000")
+
+    # Past as_of predates the registration's valid_time -> excluded.
+    past_as_of = datetime.now(UTC) - timedelta(days=10)
+    past = await service.get_coq_metrics(data["project"].project_id, as_of=past_as_of)
+    assert past.total_ac < current.total_ac
+    assert past.total_coq == Decimal("0")
+    assert past.cpq == Decimal("0")
+
+
+@pytest.mark.asyncio
 async def test_get_coq_trend_with_data(
     db: AsyncSession, actor_id: UUID, service: CostEventService
 ) -> None:

--- a/backend/tests/services/test_system_admin_service.py
+++ b/backend/tests/services/test_system_admin_service.py
@@ -1,0 +1,180 @@
+"""Tests for SystemAdminService.
+
+Covers the database dump path, specifically the change-order workflow
+config export: the ``co_workflow_config`` table supports multiple rows
+(one global default plus optional per-project overrides), but the dump
+format round-trips a single global config. ``scalar_one_or_none`` raised
+``MultipleResultsFound`` whenever more than one global config existed.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.domain.change_order_config import (
+    ChangeOrderImpactLevelConfig,
+    ChangeOrderWorkflowConfig,
+)
+from app.services.system_admin_service import SystemAdminService
+
+# SYSTEM_ACTOR used by the seed (see seed_system_config.json).
+SYSTEM_ACTOR = UUID("00000000-0000-0000-0000-000000000001")
+
+
+async def _seed_empty_global_config(db: AsyncSession) -> ChangeOrderWorkflowConfig:
+    """Insert an empty (no child rules) global config row."""
+    config = ChangeOrderWorkflowConfig(
+        config_id=uuid4(),
+        project_id=None,
+        is_active=False,
+        version=1,
+        created_by=SYSTEM_ACTOR,
+        impact_weights={},
+        score_boundaries={},
+    )
+    db.add(config)
+    await db.commit()
+    return config
+
+
+async def _seed_populated_global_config(
+    db: AsyncSession,
+) -> ChangeOrderWorkflowConfig:
+    """Insert a global config row with a single impact-level child rule."""
+    config = ChangeOrderWorkflowConfig(
+        config_id=uuid4(),
+        project_id=None,
+        is_active=True,
+        version=1,
+        created_by=SYSTEM_ACTOR,
+        impact_weights={"budget": 1.0},
+        score_boundaries={"LOW": 10},
+    )
+    db.add(config)
+    await db.commit()
+
+    impact_level = ChangeOrderImpactLevelConfig(
+        level_name="LOW",
+        level_order=1,
+        threshold_amount=10000,
+        score_threshold_min=0,
+        score_threshold_max=10,
+        is_active=True,
+        config_id=config.id,
+    )
+    db.add(impact_level)
+    await db.commit()
+    return config
+
+
+@pytest.mark.asyncio
+async def test_dump_change_order_workflow_picks_populated_global_config(
+    db: AsyncSession,
+) -> None:
+    """dump_database must not crash and must export the populated global config.
+
+    Reproduces the ``MultipleResultsFound`` crash that occurred when more
+    than one global (project_id IS NULL) ``co_workflow_config`` row existed,
+    and proves the populated global (the one with child rules) is exported
+    rather than an empty duplicate.
+    """
+    # Seed two global configs: one populated, one empty. ``scalar_one_or_none``
+    # would have raised MultipleResultsFound on this state.
+    populated = await _seed_populated_global_config(db)
+    empty = await _seed_empty_global_config(db)
+
+    service = SystemAdminService(db)
+    try:
+        result = await service.dump_database()
+    finally:
+        # Clean up rows this test created (db fixture commits) so the dev DB
+        # is not polluted (cascades remove child rule rows).
+        rows = (
+            (
+                await db.execute(
+                    select(ChangeOrderWorkflowConfig).where(
+                        ChangeOrderWorkflowConfig.id.in_([populated.id, empty.id])
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            await db.delete(row)
+        await db.commit()
+
+    co_workflow = result["system_config"]["change_order_workflow"]
+    exported_config = co_workflow["config"]
+    # The empty duplicate must NEVER shadow a populated config. The exported
+    # config must be a populated global (one with child rules) — either the
+    # seeded one or the one this test inserted, never the empty duplicate.
+    assert exported_config["id"] != str(empty.id)
+    assert exported_config["project_id"] is None
+    assert len(co_workflow["impact_levels"]) >= 1
+    # The populated config seeded by this test is exported if no older
+    # populated global exists (otherwise the seeded global is preferred).
+    exported_ids = {exported_config["id"]}
+    assert str(empty.id) not in exported_ids
+
+
+@pytest.mark.asyncio
+async def test_dump_change_order_workflow_excludes_per_project_override(
+    db: AsyncSession,
+) -> None:
+    """Per-project overrides (project_id != NULL) must not appear in the dump.
+
+    A single global config plus a per-project override is the normal runtime
+    state; the dump must export only the global config.
+    """
+    global_config = ChangeOrderWorkflowConfig(
+        config_id=uuid4(),
+        project_id=None,
+        is_active=True,
+        version=1,
+        created_by=SYSTEM_ACTOR,
+        impact_weights={},
+        score_boundaries={},
+    )
+    project_override = ChangeOrderWorkflowConfig(
+        config_id=uuid4(),
+        project_id=uuid4(),
+        is_active=True,
+        version=1,
+        created_by=SYSTEM_ACTOR,
+        impact_weights={"budget": 0.5},
+        score_boundaries={},
+    )
+    db.add_all([global_config, project_override])
+    await db.commit()
+
+    service = SystemAdminService(db)
+    try:
+        result = await service.dump_database()
+    finally:
+        rows = (
+            (
+                await db.execute(
+                    select(ChangeOrderWorkflowConfig).where(
+                        ChangeOrderWorkflowConfig.id.in_(
+                            [
+                                global_config.id,
+                                project_override.id,
+                            ]
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            await db.delete(row)
+        await db.commit()
+
+    exported_config = result["system_config"]["change_order_workflow"]["config"]
+    # The per-project override must never be exported by the global dump.
+    assert exported_config["id"] != str(project_override.id)
+    assert exported_config["project_id"] is None

--- a/backend/tests/services/test_wbs_element_service.py
+++ b/backend/tests/services/test_wbs_element_service.py
@@ -1505,3 +1505,87 @@ async def test_get_wbs_elements_merged_mode(db: AsyncSession, actor_id) -> None:
     assert total >= 1
     ids = [r.wbs_element_id for r in results]
     assert wbs_main.wbs_element_id in ids
+
+
+# ---------------------------------------------------------------------------
+# _get_all_descendants with MERGED mode on non-main branch (F2 regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_all_descendants_merged_mode_non_main_branch(
+    db: AsyncSession, actor_id
+) -> None:
+    """F2: _get_all_descendants must not crash on a CO branch in MERGED mode.
+
+    The recursive CTE previously used DISTINCT ON ... ORDER BY in the recursive
+    arms, which PostgreSQL forbids -> syntax error at "UNION". This path only
+    runs when branch_mode == MERGED and branch != "main". It must now return the
+    descendant set (main child + branch-only grandchild) without error.
+    """
+    from app.core.branching.commands import CreateBranchCommand
+    from app.core.versioning.commands import CreateVersionCommand
+    from app.core.versioning.enums import BranchMode
+
+    project = await create_test_project(db, actor_id)
+    parent = await create_test_wbs_element(
+        db, actor_id, project.project_id, code="F2.0", name="F2 Parent"
+    )
+    # Child that exists on main.
+    child_main = await create_test_wbs_element(
+        db,
+        actor_id,
+        project.project_id,
+        code="F2.1",
+        name="F2 Child on main",
+        parent_wbs_element_id=parent.wbs_element_id,
+        level=2,
+    )
+    await db.commit()
+
+    branch_name = "BR-F2-CO-001"
+
+    # Branch parent + child to the CO branch.
+    await CreateBranchCommand(
+        entity_class=WBSElement,
+        root_id=parent.wbs_element_id,
+        actor_id=actor_id,
+        new_branch=branch_name,
+        from_branch="main",
+    ).execute(db)
+    await CreateBranchCommand(
+        entity_class=WBSElement,
+        root_id=child_main.wbs_element_id,
+        actor_id=actor_id,
+        new_branch=branch_name,
+        from_branch="main",
+    ).execute(db)
+
+    # Add a grandchild that exists ONLY on the CO branch.
+    grandchild_branch_id = uuid4()
+    await CreateVersionCommand(
+        entity_class=WBSElement,
+        root_id=grandchild_branch_id,
+        actor_id=actor_id,
+        branch=branch_name,
+        project_id=project.project_id,
+        code="F2.1.1",
+        name="F2 Grandchild on CO branch",
+        parent_wbs_element_id=child_main.wbs_element_id,
+        level=3,
+    ).execute(db)
+    await db.commit()
+
+    service = WBSElementService(db)
+    # This call previously raised a SQL syntax error (500 on the EVM endpoint).
+    descendants = await service._get_all_descendants(  # noqa: SLF001
+        parent.wbs_element_id,
+        branch=branch_name,
+        branch_mode=BranchMode.MERGED,
+    )
+
+    desc_ids = {d.wbs_element_id for d in descendants}
+    # MERGED mode must surface both the child (main fallback) and the
+    # branch-only grandchild.
+    assert child_main.wbs_element_id in desc_ids
+    assert grandchild_branch_id in desc_ids

--- a/deploy/DEPLOYMENT_GUIDE.md
+++ b/deploy/DEPLOYMENT_GUIDE.md
@@ -52,6 +52,7 @@ Internet → Apache (192.168.1.21:80/443) → Traefik (192.168.1.23:8080) → Se
 - `app.backcast.duckdns.org` → 192.168.1.21
 - `api.backcast.duckdns.org` → 192.168.1.21
 - `storage.backcast.duckdns.org` → 192.168.1.21 (RustFS — presigned document downloads)
+- `www.backcast.duckdns.org` → 192.168.1.21 (Marketing/showcase website)
 
 ---
 

--- a/deploy/QUICK_REFERENCE.md
+++ b/deploy/QUICK_REFERENCE.md
@@ -209,6 +209,7 @@ docker builder prune
 | Service | URL | Authentication |
 |---------|-----|----------------|
 | Frontend | <https://app.backcast.duckdns.org> | None |
+| Website | <https://www.backcast.duckdns.org> | None |
 | Backend API | <https://api.backcast.duckdns.org> | API tokens |
 | API Docs | <https://api.backcast.duckdns.org/docs> | None |
 | Adminer (DB) | <http://db.backcast.duckdns.org> | IP whitelist |
@@ -233,6 +234,7 @@ sudo nano /etc/hosts
 ```hosts
 192.168.1.23  api.backcast.duckdns.org
 192.168.1.23  app.backcast.duckdns.org
+192.168.1.23  www.backcast.duckdns.org
 192.168.1.23  db.backcast.duckdns.org
 192.168.1.23  traefik.backcast.duckdns.org
 ```

--- a/deploy/apache/README.md
+++ b/deploy/apache/README.md
@@ -28,6 +28,7 @@ Docker Services (Backend/Frontend)
 | `app.backcast.duckdns.org.conf` | Frontend VirtualHost configuration |
 | `api.backcast.duckdns.org.conf` | Backend API VirtualHost configuration |
 | `storage.backcast.duckdns.org.conf` | RustFS (S3) VirtualHost — presigned document downloads |
+| `www.backcast.duckdns.org.conf` | Marketing/showcase website VirtualHost (static `/website`) |
 | `README.md` | This file |
 
 ---
@@ -83,6 +84,7 @@ sudo a2dissite default-ssl
 sudo a2ensite app.backcast.duckdns.org
 sudo a2ensite api.backcast.duckdns.org
 sudo a2ensite storage.backcast.duckdns.org
+sudo a2ensite www.backcast.duckdns.org
 ```
 
 **Expected output:**
@@ -164,6 +166,7 @@ sudo certbot --apache -d backcast.duckdns.org \
   -d app.backcast.duckdns.org \
   -d api.backcast.duckdns.org \
   -d storage.backcast.duckdns.org \
+  -d www.backcast.duckdns.org \
   -d db.backcast.duckdns.org
 ```
 

--- a/deploy/apache/www.backcast.duckdns.org.conf
+++ b/deploy/apache/www.backcast.duckdns.org.conf
@@ -1,0 +1,31 @@
+<VirtualHost *:80>
+    ServerName www.backcast.duckdns.org
+    Redirect permanent / https://www.backcast.duckdns.org/
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName www.backcast.duckdns.org
+
+    # SSL Configuration (use your certificates)
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/backcast.duckdns.org.crt
+    SSLCertificateKeyFile /etc/ssl/private/backcast.duckdns.org.key
+
+    # Security Headers
+    Header always set X-Frame-Options "SAMEORIGIN"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-XSS-Protection "1; mode=block"
+    Header always set Referrer-Policy "no-referrer-when-downgrade"
+
+    # Proxy to Traefik (192.168.1.23:8080)
+    # Static marketing site — no WebSocket upgrade handling needed.
+    ProxyPreserveHost On
+    ProxyRequests Off
+
+    ProxyPass / http://192.168.1.23:8080/
+    ProxyPassReverse / http://192.168.1.23:8080/
+
+    # Logging
+    ErrorLog ${APACHE_LOG_DIR}/www.backcast.duckdns.org_error.log
+    CustomLog ${APACHE_LOG_DIR}/www.backcast.duckdns.org_access.log combined
+</VirtualHost>

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -191,6 +191,38 @@ services:
       timeout: 10s
       retries: 3
 
+  # Marketing/showcase website (pure static, served at www.${DOMAIN})
+  website:
+    build:
+      context: ..
+      dockerfile: deploy/website/Dockerfile
+    image: backcast_website:latest
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - traefik-public
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-public"
+      - "traefik.http.routers.website.rule=Host(`www.${DOMAIN}`)"
+      - "traefik.http.routers.website.entrypoints=web"
+      - "traefik.http.services.website.loadbalancer.server.port=8080"
+      - "traefik.http.routers.website.middlewares=security-headers@file"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 128M
+        reservations:
+          cpus: '0.1'
+          memory: 32M
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
   # Adminer (Database GUI)
   adminer:
     image: adminer:latest

--- a/deploy/website/Dockerfile
+++ b/deploy/website/Dockerfile
@@ -1,0 +1,17 @@
+# Static marketing/showcase website (pure HTML/CSS/JS — no build step).
+# Served by nginx and routed via Traefik as www.${DOMAIN}.
+# Build context is the repo root (see deploy/docker-compose.yml), so paths
+# below are relative to the repo root.
+FROM nginx:alpine
+
+# Custom nginx config (static serving on :8080)
+COPY deploy/website/nginx.conf /etc/nginx/nginx.conf
+
+# Site content
+COPY website/ /usr/share/nginx/html
+
+EXPOSE 8080
+
+# nginx:alpine's default ENTRYPOINT/CMD ("nginx -g daemon off;") is sufficient.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1

--- a/deploy/website/nginx.conf
+++ b/deploy/website/nginx.conf
@@ -1,0 +1,62 @@
+user nginx;
+worker_processes auto;
+pid /run/nginx.pid;
+error_log /var/log/nginx/error.log warn;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Logging
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /var/log/nginx/access.log main;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Content-Security-Policy "default-src 'self' http: https: ws: wss: data: blob: 'unsafe-inline'; frame-ancestors 'self';" always;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml text/javascript application/json application/javascript application/xml+rss application/rss+xml font/truetype font/opentype application/vnd.ms-fontobject image/svg+xml;
+
+    server {
+        listen 8080;
+        server_name _;
+        root /usr/share/nginx/html;
+        index index.html;
+
+        # Security
+        server_tokens off;
+
+        # Static marketing site — serve files, fall back to index.html for the root
+        location / {
+            try_files $uri $uri/ /index.html;
+            add_header Cache-Control "public, max-age=3600";
+        }
+
+        # Static assets with long cache
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
+
+        # Health check endpoint
+        location /health {
+            access_log off;
+            return 200 "OK";
+            add_header Content-Type text/plain;
+        }
+    }
+}

--- a/frontend/src/api/generated/models/PortfolioProjectMetrics.ts
+++ b/frontend/src/api/generated/models/PortfolioProjectMetrics.ts
@@ -66,5 +66,13 @@ export type PortfolioProjectMetrics = {
      * ΔEAC forecast drift = latest EAC minus previous EAC (summed over the project's work-package forecasts). Null when no forecast history exists.
      */
     delta_eac?: (number | null);
+    /**
+     * Project start date (ISO). Null when the project has no schedule span.
+     */
+    start_date?: (string | null);
+    /**
+     * Project end date (ISO). Null when the project has no schedule span.
+     */
+    end_date?: (string | null);
 };
 

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -131,14 +131,18 @@ export const queryKeys = createQueryKeys("backcast-evs", {
     detail: (id: string, context?: unknown) =>
       ["cost-events", "detail", id, context] as const,
     history: (id: string) => ["cost-events", "history", id] as const,
-    summary: (projectId: string) =>
-      ["cost-events", "summary", projectId] as const,
+    summary: (projectId: string, context?: { asOf?: string }) =>
+      ["cost-events", "summary", projectId, context] as const,
     allocations: (id: string) =>
       ["cost-events", "allocations", id] as const,
-    coqMetrics: (projectId: string) =>
-      ["cost-events", "coqMetrics", projectId] as const,
-    coqTrend: (projectId: string, granularity?: string) =>
-      ["cost-events", "coqTrend", projectId, granularity] as const,
+    coqMetrics: (projectId: string, context?: { asOf?: string }) =>
+      ["cost-events", "coqMetrics", projectId, context] as const,
+    coqTrend: (
+      projectId: string,
+      granularity: "week" | "month",
+      context?: { asOf?: string },
+    ) =>
+      ["cost-events", "coqTrend", projectId, granularity, context] as const,
   },
 
   // Cost Event Types (was: package-types)

--- a/frontend/src/components/common/PanelCard.tsx
+++ b/frontend/src/components/common/PanelCard.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { Card, Space, theme } from "antd";
+
+type CardStyles = React.ComponentProps<typeof Card>["styles"];
+
+export interface PanelCardProps {
+  /** Optional leading icon rendered in the primary color. */
+  icon?: React.ReactNode;
+  /** Panel title text. */
+  title: string;
+  /** Extra content rendered in the card header (e.g. action buttons, status tag). */
+  extra?: React.ReactNode;
+  /** Inline style for the underlying Card. */
+  style?: React.CSSProperties;
+  /** Pass-through for antd Card `styles` (e.g. body padding overrides). */
+  styles?: CardStyles;
+  /** className for the underlying Card. */
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * PanelCard - Shared content panel with a standardized title style.
+ *
+ * Wraps antd `Card` (size="small") with a canonical title formatting
+ * (fontSizeLG + fontWeightStrong) and a primary-colored icon, matching
+ * the title style used by `EntityInfoCard` and the entity overview pages.
+ *
+ * The underlying Card's `ref` (HTMLDivElement), `styles`, and `className`
+ * are passed through, so callers can attach scroll-to-section refs and
+ * override body padding exactly as they would on a raw `Card`.
+ *
+ * @example
+ * ```tsx
+ * <PanelCard icon={<DollarOutlined />} title="Budget Summary" extra={<Tag>Healthy</Tag>}>
+ *   <Row>...</Row>
+ * </PanelCard>
+ * ```
+ */
+export const PanelCard = React.forwardRef<HTMLDivElement, PanelCardProps>(
+  ({ icon, title, extra, style, styles, className, children }, ref) => {
+    const { token } = theme.useToken();
+
+    return (
+      <Card
+        ref={ref}
+        size="small"
+        className={className}
+        style={style}
+        styles={{
+          header: { paddingBlock: token.paddingSM, paddingInline: token.paddingLG },
+          ...styles,
+        }}
+        title={
+          <Space>
+            {icon && (
+              <span style={{ color: token.colorPrimary, display: "inline-flex" }}>
+                {icon}
+              </span>
+            )}
+            <span
+              style={{
+                fontSize: token.fontSizeLG,
+                fontWeight: token.fontWeightStrong,
+                color: token.colorText,
+              }}
+            >
+              {title}
+            </span>
+          </Space>
+        }
+        extra={extra}
+      >
+        {children}
+      </Card>
+    );
+  },
+);
+PanelCard.displayName = "PanelCard";

--- a/frontend/src/components/common/entityInfoDescriptionsProps.ts
+++ b/frontend/src/components/common/entityInfoDescriptionsProps.ts
@@ -18,7 +18,7 @@ export const entityInfoDescriptionsProps = (
   token: ReturnType<typeof theme.useToken>["token"]
 ) => ({
   size: "middle" as const,
-  column: { xs: 1, sm: 2 },
+  column: 1,
   colon: true,
   labelStyle: {
     fontWeight: 600,

--- a/frontend/src/components/explorer/CostElementDetailCards.tsx
+++ b/frontend/src/components/explorer/CostElementDetailCards.tsx
@@ -316,7 +316,7 @@ export const CostElementDetailCards = ({
         {/* System info - collapsed */}
         <Collapse ghost>
           <Collapse.Panel header="System Information" key="system">
-            <Descriptions column={2} size="small">
+            <Descriptions column={1} size="small">
               <Descriptions.Item label="ID">
                 {costElement.id}
               </Descriptions.Item>

--- a/frontend/src/components/explorer/ExplorerCard.tsx
+++ b/frontend/src/components/explorer/ExplorerCard.tsx
@@ -27,7 +27,7 @@ export const ExplorerCard = ({
       styles={{
         header: {
           background: token.colorBgLayout,
-          padding: `${token.paddingSM}px ${token.paddingMD}px`,
+          padding: `${token.paddingSM}px ${token.paddingLG}px`,
           borderBottom: `1px solid ${token.colorBorderSecondary}`,
           minHeight: "auto",
         },

--- a/frontend/src/components/explorer/ProjectDetailCards.tsx
+++ b/frontend/src/components/explorer/ProjectDetailCards.tsx
@@ -303,7 +303,7 @@ export const ProjectDetailCards = ({ projectId }: ProjectDetailCardsProps) => {
         {/* System info - collapsed by default */}
         <Collapse ghost>
           <Collapse.Panel header="System Information" key="system">
-            <Descriptions column={2} size="small">
+            <Descriptions column={1} size="small">
               <Descriptions.Item label="ID">{project.id}</Descriptions.Item>
               <Descriptions.Item label="Project ID">
                 {project.project_id}

--- a/frontend/src/components/explorer/WBSElementDetailCards.tsx
+++ b/frontend/src/components/explorer/WBSElementDetailCards.tsx
@@ -242,7 +242,7 @@ export const WBSElementDetailCards = ({ wbsElementId }: WBSElementDetailCardsPro
         {/* System info - collapsed */}
         <Collapse ghost>
           <Collapse.Panel header="System Information" key="system">
-            <Descriptions column={2} size="small">
+            <Descriptions column={1} size="small">
               <Descriptions.Item label="ID">{wbe.id}</Descriptions.Item>
               <Descriptions.Item label="WBE ID">{wbe.wbs_element_id}</Descriptions.Item>
               <Descriptions.Item label="Project ID">

--- a/frontend/src/features/change-orders/api/useChangeOrders.ts
+++ b/frontend/src/features/change-orders/api/useChangeOrders.ts
@@ -43,11 +43,15 @@ const getPaginationParams = (params?: ChangeOrderListParams) => {
  * Change orders are always scoped to a specific project.
  */
 export const useChangeOrders = (params: ChangeOrderListParams) => {
-  const { asOf } = useTimeMachineParams();
+  const { mode: tmMode, branch: tmBranch, asOf } = useTimeMachineParams();
+  // Explicit params.branch wins (e.g. fixed dashboard branch); fall back to TM.
+  const branch = params.branch || tmBranch || "main";
 
   return useQuery({
     queryKey: queryKeys.changeOrders.list(params.projectId, {
       ...params,
+      branch,
+      mode: tmMode,
       asOf,
     }),
     queryFn: async () => {
@@ -59,7 +63,8 @@ export const useChangeOrders = (params: ChangeOrderListParams) => {
         query: {
           project_id: params.projectId,
           ...serverParams,
-          branch: params.branch || "main",
+          branch,
+          branch_mode: tmMode,
           as_of: asOf || undefined,
         },
       }) as Promise<PaginatedResponse<ChangeOrderPublic>>;

--- a/frontend/src/features/change-orders/components/ApprovalInfo.tsx
+++ b/frontend/src/features/change-orders/components/ApprovalInfo.tsx
@@ -217,7 +217,7 @@ export function ApprovalInfo({
               <DollarOutlined /> Financial Impact
             </Text>
             <Descriptions
-              column={2}
+              column={1}
               size="small"
               style={{ marginTop: token.marginXS }}
               items={[

--- a/frontend/src/features/change-orders/components/ChangeOrderDetailsSection.tsx
+++ b/frontend/src/features/change-orders/components/ChangeOrderDetailsSection.tsx
@@ -22,7 +22,7 @@ export function ChangeOrderDetailsSection({
 
   return (
     <Descriptions
-      column={2}
+      column={1}
       size="small"
       bordered
       items={[

--- a/frontend/src/features/cost-events/api/useCostEvents.ts
+++ b/frontend/src/features/cost-events/api/useCostEvents.ts
@@ -215,7 +215,7 @@ export const useCostEventSummary = (projectId: string) => {
   const { asOf } = useTimeMachineParams();
 
   return useQuery<CostEventSummary>({
-    queryKey: queryKeys.costEvents.summary(projectId),
+    queryKey: queryKeys.costEvents.summary(projectId, { asOf }),
     queryFn: async () => {
       return await __request(OpenAPI, {
         method: "GET",
@@ -255,13 +255,18 @@ export const useCostEventAllocations = (costEventId: string) => {
 // ---------------------------------------------------------------------------
 
 export const useCOQMetrics = (projectId: string) => {
+  const { asOf } = useTimeMachineParams();
+
   return useQuery<COQMetrics>({
-    queryKey: queryKeys.costEvents.coqMetrics(projectId),
+    queryKey: queryKeys.costEvents.coqMetrics(projectId, { asOf }),
     queryFn: async () => {
       return await __request(OpenAPI, {
         method: "GET",
         url: "/api/v1/cost-events/project/{project_id}/coq-metrics",
         path: { project_id: projectId },
+        query: {
+          as_of: asOf || undefined,
+        },
         errors: { 422: "Validation Error" },
       });
     },
@@ -280,7 +285,7 @@ export const useCOQTrend = (
   const { asOf } = useTimeMachineParams();
 
   return useQuery<COQTrendResponse>({
-    queryKey: queryKeys.costEvents.coqTrend(projectId, granularity),
+    queryKey: queryKeys.costEvents.coqTrend(projectId, granularity, { asOf }),
     queryFn: async () => {
       return await __request(OpenAPI, {
         method: "GET",

--- a/frontend/src/features/cost-registration/api/useCostRegistrations.ts
+++ b/frontend/src/features/cost-registration/api/useCostRegistrations.ts
@@ -59,12 +59,13 @@ interface CostRegistrationListParams {
  * @returns TanStack Query result with paginated cost registrations
  */
 export const useCostRegistrations = (params?: CostRegistrationListParams) => {
-  const { asOf } = useTimeMachineParams();
+  const { mode, branch: tmBranch, asOf } = useTimeMachineParams();
+  const branch = tmBranch || "main";
   const filterId =
     params?.cost_element_id || params?.work_package_id || params?.wbs_element_id || params?.project_id || "";
 
   return useQuery<PaginatedResponse<CostRegistrationRead>>({
-    queryKey: queryKeys.costRegistrations.list(filterId, { ...params, asOf }),
+    queryKey: queryKeys.costRegistrations.list(filterId, { ...params, asOf, branch, mode }),
     queryFn: async () => {
       const {
         cost_element_id,
@@ -96,8 +97,8 @@ export const useCostRegistrations = (params?: CostRegistrationListParams) => {
         query: {
           page,
           per_page: perPage,
-          branch: "main",
-          mode: "merged",
+          branch,
+          mode,
           cost_element_id: cost_element_id || undefined,
           wbs_element_id: wbs_element_id || undefined,
           project_id: project_id || undefined,

--- a/frontend/src/features/evm/api/useEVMMetrics.ts
+++ b/frontend/src/features/evm/api/useEVMMetrics.ts
@@ -124,6 +124,7 @@ export function useEVMMetrics(
     queryKey: queryKeys.evm.metrics(entityType, entityId, {
       branch,
       controlDate,
+      mode: tmMode,
     }),
     queryFn: async () => {
       // For cost elements, use the existing endpoint
@@ -211,6 +212,7 @@ export function useEVMTimeSeries(
       branch,
       controlDate,
       granularity,
+      mode: tmMode,
     }),
     queryFn: async () => {
       return await __request(OpenAPI, {
@@ -274,6 +276,7 @@ export function useEVMMetricsBatch(
     queryKey: queryKeys.evm.batch(entityType, entityIds || [], {
       branch,
       controlDate,
+      mode: tmMode,
     }),
     queryFn: async () => {
       // Use the batch endpoint for all entity types

--- a/frontend/src/features/schedule-baselines/components/GanttChart/GanttChartOptions.ts
+++ b/frontend/src/features/schedule-baselines/components/GanttChart/GanttChartOptions.ts
@@ -57,19 +57,100 @@ function progressionColor(
 }
 
 /**
+ * Default bar/row tooltip formatter for a Gantt row.
+ *
+ * Extracted verbatim from the inline `tooltip.formatter` body so alternate
+ * hosts (e.g. the portfolio Gantt widget, which renders project spans instead
+ * of cost elements) can supply their own `tooltipFormatter` while reusing the
+ * same engine. The default (cost-element / WBE) path is byte-identical to the
+ * pre-extraction inline formatter.
+ *
+ * @param row      - The matched GanttRow (params.data[3])
+ * @param currency - ISO currency code for the Budget line
+ * @param colors   - Theme palette (carries textSecondary for muted labels)
+ */
+export function defaultGanttTooltip(
+  row: GanttRow,
+  currency: string,
+  colors: EChartsColorPalette,
+): string {
+  const start = row.startDate!;
+  const end = row.endDate!;
+  const durationDays = Math.ceil(
+    (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+  );
+  const format = (d: Date) =>
+    d.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+
+  // WBE group header tooltip
+  if (row.isWbe) {
+    return `<div style="font-weight:600;margin-bottom:4px;">${row.name}</div>
+<div style="color:${colors.textSecondary};font-size:11px;margin-bottom:4px;">WBE Group</div>
+<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>Start</span><span style="font-weight:600;">${format(start)}</span>
+</div>
+<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>End</span><span style="font-weight:600;">${format(end)}</span>
+</div>
+<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>Duration</span><span style="font-weight:600;">${durationDays} days</span>
+</div>
+<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>Items</span><span style="font-weight:600;">${row.childrenCount}</span>
+</div>`;
+  }
+
+  // Cost element tooltip
+  return `<div style="font-weight:600;margin-bottom:4px;">${row.name}</div>
+<div style="color:${colors.textSecondary};font-size:11px;margin-bottom:4px;">${row.wbeCode}</div>
+<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>Start</span><span style="font-weight:600;">${format(start)}</span>
+</div>
+<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>End</span><span style="font-weight:600;">${format(end)}</span>
+</div>
+<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>Duration</span><span style="font-weight:600;">${durationDays} days</span>
+</div>
+<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>Budget</span><span style="font-weight:600;">${new Intl.NumberFormat("en-US", { style: "currency", currency, minimumFractionDigits: 0 }).format(row.budgetAmount)}</span>
+</div>
+${
+  row.progressionType
+    ? `<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>Progression</span><span style="font-weight:600;">${row.progressionType}</span>
+</div>`
+    : ""
+}`;
+}
+
+/**
  * Build ECharts option for the Gantt chart.
  *
- * @param rows            - Transformed GanttRow array
- * @param dependencies    - Dependency links (rendered as right-angle arrows)
- * @param scheduleIndex   - costElementId → y-index map (dependency resolution)
- * @param projectStart    - Project start date (x-axis min clamp)
- * @param projectEnd      - Project end date (x-axis max clamp)
- * @param colors          - Theme palette (tokenised; carries pv/ev/forecast)
- * @param tooltipConfig   - Tooltip config from useEChartsTheme()
- * @param currency        - ISO currency code for tooltips
- * @param config          - Full chart config (mode/zoom/density/flags)
- * @param hoveredDepIndex - Dependency data index currently hovered (-1 = none).
- *                          Lifts that link to full opacity / thicker stroke.
+ * @param rows              - Transformed GanttRow array
+ * @param dependencies      - Dependency links (rendered as right-angle arrows)
+ * @param scheduleIndex     - costElementId → y-index map (dependency resolution)
+ * @param projectStart      - Project start date (x-axis min clamp)
+ * @param projectEnd        - Project end date (x-axis max clamp)
+ * @param colors            - Theme palette (tokenised; carries pv/ev/forecast)
+ * @param tooltipConfig     - Tooltip config from useEChartsTheme()
+ * @param currency          - ISO currency code for tooltips
+ * @param config            - Full chart config (mode/zoom/density/flags)
+ * @param hoveredDepIndex   - Dependency data index currently hovered (-1 = none).
+ *                            Lifts that link to full opacity / thicker stroke.
+ * @param barColorFor       - Optional override for the cost-element bar
+ *                            foreground colour. Defaults to
+ *                            `(row, c) => progressionColor(row.progressionType, c)`
+ *                            (the pre-generalisation behaviour). Alternate
+ *                            hosts (portfolio Gantt) supply an RAG-derived colour.
+ * @param tooltipFormatter  - Optional override for the bar/row tooltip body.
+ *                            Defaults to {@link defaultGanttTooltip} (the exact
+ *                            pre-extraction inline body). Alternate hosts pass
+ *                            a host-specific formatter.
  */
 export function buildGanttOptions(
   rows: GanttRow[],
@@ -82,6 +163,12 @@ export function buildGanttOptions(
   currency: string,
   config: GanttChartConfig,
   hoveredDepIndex: number = -1,
+  barColorFor?: (row: GanttRow, colors: EChartsColorPalette) => string,
+  tooltipFormatter?: (
+    row: GanttRow,
+    currency: string,
+    colors: EChartsColorPalette,
+  ) => string,
 ): EChartsOption {
   const preset = getZoomPreset(config.zoom);
   const { density, gridLeft, showDependencies, showDataZoom, showTimeHeader } =
@@ -171,58 +258,10 @@ export function buildGanttOptions(
         }
 
         const row = p.data[3] as GanttRow;
-        const start = row.startDate!;
-        const end = row.endDate!;
-        const durationDays = Math.ceil(
-          (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
-        );
-        const format = (d: Date) =>
-          d.toLocaleDateString("en-US", {
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-          });
-
-        // WBE group header tooltip
-        if (row.isWbe) {
-          return `<div style="font-weight:600;margin-bottom:4px;">${row.name}</div>
-<div style="color:${colors.textSecondary};font-size:11px;margin-bottom:4px;">WBE Group</div>
-<div style="display:flex;justify-content:space-between;gap:24px;">
-  <span>Start</span><span style="font-weight:600;">${format(start)}</span>
-</div>
-<div style="display:flex;justify-content:space-between;gap:24px;">
-  <span>End</span><span style="font-weight:600;">${format(end)}</span>
-</div>
-<div style="display:flex;justify-content:space-between;gap:24px;">
-  <span>Duration</span><span style="font-weight:600;">${durationDays} days</span>
-</div>
-<div style="display:flex;justify-content:space-between;gap:24px;">
-  <span>Items</span><span style="font-weight:600;">${row.childrenCount}</span>
-</div>`;
-        }
-
-        // Cost element tooltip
-        return `<div style="font-weight:600;margin-bottom:4px;">${row.name}</div>
-<div style="color:${colors.textSecondary};font-size:11px;margin-bottom:4px;">${row.wbeCode}</div>
-<div style="display:flex;justify-content:space-between;gap:24px;">
-  <span>Start</span><span style="font-weight:600;">${format(start)}</span>
-</div>
-<div style="display:flex;justify-content:space-between;gap:24px;">
-  <span>End</span><span style="font-weight:600;">${format(end)}</span>
-</div>
-<div style="display:flex;justify-content:space-between;gap:24px;">
-  <span>Duration</span><span style="font-weight:600;">${durationDays} days</span>
-</div>
-<div style="display:flex;justify-content:space-between;gap:24px;">
-  <span>Budget</span><span style="font-weight:600;">${new Intl.NumberFormat("en-US", { style: "currency", currency, minimumFractionDigits: 0 }).format(row.budgetAmount)}</span>
-</div>
-${
-  row.progressionType
-    ? `<div style="display:flex;justify-content:space-between;gap:24px;">
-  <span>Progression</span><span style="font-weight:600;">${row.progressionType}</span>
-</div>`
-    : ""
-}`;
+        // Pluggable bar/row tooltip body. Defaults to the verbatim
+        // pre-extraction inline formatter; alternate hosts (portfolio Gantt)
+        // supply a host-specific formatter via `tooltipFormatter`.
+        return (tooltipFormatter ?? defaultGanttTooltip)(row, currency, colors);
       },
     },
     grid: [
@@ -490,7 +529,10 @@ ${
 
           // Cost element bar: dual-layer (background + progression-coloured foreground)
           const y = startCoord[1] - barHeight / 2;
-          const fgColor = progressionColor(row.progressionType, colors);
+          const fgColor = (
+            barColorFor ??
+            ((row, c) => progressionColor(row.progressionType, c))
+          )(row, colors);
           return {
             type: "group",
             children: [

--- a/frontend/src/features/schedule-baselines/components/GanttChart/ScheduleTimeline.tsx
+++ b/frontend/src/features/schedule-baselines/components/GanttChart/ScheduleTimeline.tsx
@@ -59,8 +59,22 @@ const MIN_HEIGHT = 200;
 const MAX_HEIGHT = 1200;
 
 export interface ScheduleTimelineProps {
-  /** Raw Gantt data response (items + dates + dependencies). */
-  data: GanttDataResponse;
+  /**
+   * Raw Gantt data response (items + dates + dependencies). REQUIRED for the
+   * legacy transform path; OMITTED by alternate hosts (e.g. the portfolio
+   * Gantt widget) that supply pre-built {@link ScheduleTimelineProps.rows}
+   * instead. When `rows` is provided, `data` is ignored.
+   */
+  data?: GanttDataResponse;
+  /**
+   * Pre-built display rows. When provided, this component SKIPS
+   * `transformGanttData` + the collapse computation and renders these rows
+   * directly (deriving projectStart/projectEnd from the rows' min start /
+   * max end). Alternate hosts with their own row model (e.g. portfolio
+   * project spans) use this. When absent, the legacy `data` → transform path
+   * runs unchanged.
+   */
+  rows?: GanttRow[];
   /** ISO currency code for tooltips. */
   currency: string;
   /** Tokenised theme palette. */
@@ -69,12 +83,27 @@ export interface ScheduleTimelineProps {
   tooltipConfig: EChartsTooltipConfig;
   /** Full chart config (mode/zoom/density/flags). */
   config: GanttChartConfig;
-  /** Collapsed WBE ids set. */
-  collapsedWbeIds: Set<string>;
+  /** Collapsed WBE ids set (legacy path only; ignored when `rows` is set). */
+  collapsedWbeIds?: Set<string>;
   /** Live-instance ref (owned by useScheduleViewport). */
   chartRef?: React.MutableRefObject<ECharts | null>;
   /** Optional bar-click handler (defaults to no-op). */
   onBarClick?: (row: GanttRow) => void;
+  /**
+   * Optional override for the bar foreground colour (forwarded to
+   * `buildGanttOptions`). Defaults to the progression-type colour inside the
+   * builder. Alternate hosts supply an RAG-derived colour.
+   */
+  barColorFor?: (row: GanttRow, colors: EChartsColorPalette) => string;
+  /**
+   * Optional override for the bar/row tooltip body (forwarded to
+   * `buildGanttOptions`). Defaults to `defaultGanttTooltip` inside the builder.
+   */
+  tooltipFormatter?: (
+    row: GanttRow,
+    currency: string,
+    colors: EChartsColorPalette,
+  ) => string;
   /**
    * Optional explicit height; otherwise derived from row count + density.
    *
@@ -92,6 +121,7 @@ export interface ScheduleTimelineProps {
  */
 export const ScheduleTimeline: React.FC<ScheduleTimelineProps> = ({
   data,
+  rows: rowsProp,
   currency,
   colors,
   tooltipConfig,
@@ -99,29 +129,47 @@ export const ScheduleTimeline: React.FC<ScheduleTimelineProps> = ({
   collapsedWbeIds,
   chartRef,
   onBarClick,
+  barColorFor,
+  tooltipFormatter,
   height,
   loading,
 }) => {
   const { density } = config;
   const headerFooter = density.headerHeight + density.bottomPadding;
 
-  // Transform flat API data into display rows
-  const rows = useMemo(
-    () => transformGanttData(data?.items ?? [], collapsedWbeIds),
-    [data, collapsedWbeIds],
-  );
+  // Rows-mode (alternate host): use the pre-built rows directly, skipping the
+  // transform + collapse computation. Legacy data-mode: transform flat API
+  // items into display rows (unchanged path for the schedule page + mini-gantt).
+  const rows = useMemo(() => {
+    if (rowsProp) return rowsProp;
+    return transformGanttData(data?.items ?? [], collapsedWbeIds ?? new Set());
+  }, [rowsProp, data, collapsedWbeIds]);
 
-  // Schedule index for dependency-arrow coordinate resolution
+  // Schedule index for dependency-arrow coordinate resolution. Harmless in
+  // rows-mode (no deps there); kept for the shared builder signature.
   const scheduleIndex = useMemo(() => buildScheduleBaselineIndex(rows), [rows]);
 
-  const projectStart = useMemo(
-    () => (data?.project_start ? new Date(data.project_start) : null),
-    [data],
-  );
-  const projectEnd = useMemo(
-    () => (data?.project_end ? new Date(data.project_end) : null),
-    [data],
-  );
+  // projectStart/projectEnd: in rows-mode derive from the rows' min start /
+  // max end (so the x-axis clamps to the rendered spans); in data-mode read
+  // them from the response exactly as before.
+  const projectStart = useMemo(() => {
+    if (rowsProp) {
+      const starts = rowsProp
+        .map((r) => r.startDate?.getTime() ?? null)
+        .filter((t): t is number => t !== null);
+      return starts.length ? new Date(Math.min(...starts)) : null;
+    }
+    return data?.project_start ? new Date(data.project_start) : null;
+  }, [rowsProp, data]);
+  const projectEnd = useMemo(() => {
+    if (rowsProp) {
+      const ends = rowsProp
+        .map((r) => r.endDate?.getTime() ?? null)
+        .filter((t): t is number => t !== null);
+      return ends.length ? new Date(Math.max(...ends)) : null;
+    }
+    return data?.project_end ? new Date(data.project_end) : null;
+  }, [rowsProp, data]);
 
   // Hovered dependency index — tracked via onEvents mouseover/mouseout on the
   // dependency series. Lifts the hovered link to full opacity / thicker stroke
@@ -142,6 +190,8 @@ export const ScheduleTimeline: React.FC<ScheduleTimelineProps> = ({
         currency,
         config,
         hoveredDepIndex,
+        barColorFor,
+        tooltipFormatter,
       ),
     [
       rows,
@@ -154,6 +204,8 @@ export const ScheduleTimeline: React.FC<ScheduleTimelineProps> = ({
       currency,
       config,
       hoveredDepIndex,
+      barColorFor,
+      tooltipFormatter,
     ],
   );
 

--- a/frontend/src/features/wbs-elements/pages/WBSElementDetail.tsx
+++ b/frontend/src/features/wbs-elements/pages/WBSElementDetail.tsx
@@ -97,7 +97,7 @@ export const WBSElementDetail: React.FC<WBSElementDetailProps> = ({ wbsElementId
       {/* WBS Element Basic Information */}
       <Card style={{ marginBottom: token.marginLG }}>
         <Title level={2}>{wbsData.name}</Title>
-        <Descriptions column={2} bordered>
+        <Descriptions column={1} bordered>
           <Descriptions.Item label="Code">{wbsData.code}</Descriptions.Item>
           <Descriptions.Item label="Level">{wbsData.level}</Descriptions.Item>
           <Descriptions.Item label="Description" span={2}>

--- a/frontend/src/features/widgets/components/WidgetPalette.tsx
+++ b/frontend/src/features/widgets/components/WidgetPalette.tsx
@@ -21,6 +21,7 @@ const CATEGORY_LABELS: Record<WidgetCategory, string> = {
   diagnostic: "Diagnostics",
   breakdown: "Breakdowns",
   action: "Actions",
+  schedule: "Schedule",
   settings: "Settings",
 };
 
@@ -30,6 +31,7 @@ const CATEGORY_ORDER: WidgetCategory[] = [
   "diagnostic",
   "breakdown",
   "action",
+  "schedule",
   "settings",
 ];
 

--- a/frontend/src/features/widgets/definitions/PortfolioGanttWidget.tsx
+++ b/frontend/src/features/widgets/definitions/PortfolioGanttWidget.tsx
@@ -1,0 +1,261 @@
+/**
+ * Portfolio Timeline (Gantt) widget — cross-project start→end span chart.
+ *
+ * Phase 4 of the global-dashboard-widgets initiative. Renders one bar per
+ * portfolio project that has BOTH a start_date and an end_date (the portfolio
+ * EVM response now carries these; projects missing either are skipped). Bars
+ * are coloured by the project's schedule RAG band (SPI) so a portfolio glance
+ * reads at-risk projects instantly.
+ *
+ * Reuses the shared Gantt engine (`<ScheduleTimeline>` in rows-mode +
+ * `defaultCompactConfig`) — the only host-specific concerns supplied here are:
+ *   - the GanttRow[] built from `usePortfolioEVM().projects`
+ *   - a `barColorFor` override (SPI RAG instead of progression type)
+ *   - a `tooltipFormatter` override (project name + status + date range + CPI/SPI)
+ *
+ * LOCKED constraints (design doc §5.2, G16/G17) — identical to the sibling
+ * portfolio widgets:
+ *  - Branch FROZEN to `main`/`merged` (G16). NEVER reads `ctx.branch`/`ctx.mode`.
+ *  - Reads status / rag from `ctx.portfolioFilter` (NOT the store directly).
+ *    When the host (Phase 8) has not populated `portfolioFilter`, all filters
+ *    are null → unfiltered (today/main/merged).
+ *
+ * Currency: the portfolio EVM response is already in the portfolio base
+ * currency, and the sibling widgets (`PortfolioProjectsTableWidget`,
+ * `PortfolioChangeOrderPipelineWidget`) format as "EUR" — this widget matches
+ * that (the tooltip budget line is always 0 here, so the currency is cosmetic,
+ * but staying consistent avoids a per-widget base-currency hook that does not
+ * exist for portfolio scope).
+ *
+ * Source design: docs/03-project-plan/iterations/2026-06-29-global-dashboard-widgets/
+ *   global-dashboard-widgets-design.md §5.2 (portfolio-gantt) + §7 Phase 4.
+ */
+
+import { BarChartOutlined } from "@ant-design/icons";
+import { Empty, Typography } from "antd";
+import { useMemo, type FC } from "react";
+import { useDashboardContext } from "../context/useDashboardContext";
+import { usePortfolioEVM } from "@/features/portfolio/api/usePortfolioEVM";
+import { useEChartsTheme } from "@/features/evm/utils/echartsTheme";
+import type { EChartsColorPalette } from "@/features/evm/utils/echartsTheme";
+import { formatValue } from "@/features/evm/utils/formatters";
+import { WidgetShell } from "../components/WidgetShell";
+import { registerWidget, widgetTypeId } from "..";
+import type { WidgetComponentProps } from "../types";
+import type { PortfolioProjectMetrics } from "@/api/generated/models/PortfolioProjectMetrics";
+import { indexBand, ragBand } from "./shared/portfolioMetrics";
+import type { GanttRow } from "@/features/schedule-baselines/components/GanttChart/GanttDataTransformer";
+import { ScheduleTimeline } from "@/features/schedule-baselines/components/GanttChart/ScheduleTimeline";
+import { defaultCompactConfig } from "@/features/schedule-baselines/components/GanttChart/config";
+
+const { Text } = Typography;
+
+/** Portfolio base currency — matches the sibling portfolio widgets. */
+const PORTFOLIO_CURRENCY = "EUR";
+
+interface PortfolioGanttConfig {
+  // No configurable knobs yet — reserved for future zoom/density overrides.
+  [key: string]: never;
+}
+
+/** Format a Date as a short locale date for the tooltip range line. */
+function formatDate(d: Date): string {
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+const PortfolioGanttComponent: FC<
+  WidgetComponentProps<PortfolioGanttConfig>
+> = ({
+  instanceId,
+  isEditing,
+  onRemove,
+  onConfigure,
+  onFullscreen,
+  widgetType,
+  dashboardName,
+}) => {
+  const ctx = useDashboardContext();
+
+  // G16: branch FROZEN to main/merged (never reads ctx.branch / ctx.mode).
+  const { data, isLoading, error, refetch } = usePortfolioEVM({
+    controlDate: ctx.portfolioFilter?.controlDate ?? null,
+    branch: "main",
+    branchMode: "merged",
+  });
+
+  const { colors, tooltipConfig } = useEChartsTheme();
+
+  const statusFilter = ctx.portfolioFilter?.status ?? null;
+  const ragFilter = ctx.portfolioFilter?.rag ?? null;
+
+  // Apply the portfolio status + RAG filter the SAME way the sibling widgets do
+  // (verbatim filter predicate from PortfolioProjectsTableWidget). Done before
+  // building rows so a filtered-out project never renders a bar.
+  const filteredProjects = useMemo(() => {
+    const rows = data?.projects ?? [];
+    return rows.filter((row) => {
+      if (statusFilter && statusFilter.length > 0) {
+        if (!statusFilter.includes(row.status)) return false;
+      }
+      if (ragFilter && ragFilter.length > 0) {
+        const band = ragBand(row.cpi ?? null, row.spi ?? null);
+        if (band === "Unknown" || !ragFilter.includes(band)) return false;
+      }
+      return true;
+    });
+  }, [data?.projects, statusFilter, ragFilter]);
+
+  // Project lookup keyed by project_id so barColorFor / tooltipFormatter can
+  // recover the source PortfolioProjectMetrics from a GanttRow (the row's
+  // wbsElementId is set to the project_id — see buildRows below).
+  const projectById = useMemo(() => {
+    const m = new Map<string, PortfolioProjectMetrics>();
+    for (const p of filteredProjects) m.set(p.project_id, p);
+    return m;
+  }, [filteredProjects]);
+
+  // Build GanttRow[]: one row per project that has BOTH start_date and
+  // end_date (skip projects with null on either). Sorted ascending by startDate.
+  const rows = useMemo<GanttRow[]>(() => {
+    return filteredProjects
+      .filter(
+        (p) => p.start_date != null && p.end_date != null,
+      )
+      .map((p) => ({
+        name: p.name,
+        level: 1,
+        // costElementId = project_id keeps buildScheduleBaselineIndex
+        // well-formed (there are no deps in portfolio mode).
+        costElementId: p.project_id,
+        wbsElementId: p.project_id,
+        wbeCode: "",
+        startDate: new Date(p.start_date as string),
+        endDate: new Date(p.end_date as string),
+        progressionType: null,
+        budgetAmount: 0,
+        isWbe: false,
+        collapsed: false,
+        childrenCount: 0,
+      }))
+      .sort((a, b) => a.startDate!.getTime() - b.startDate!.getTime());
+  }, [filteredProjects]);
+
+  // Bar colour: SPI RAG band. Red/amber/green from the theme palette's
+  // error/warning/success tokens; neutral (textSecondary) when SPI is null.
+  const barColorFor = useMemo(
+    () =>
+      (row: GanttRow, c: EChartsColorPalette): string => {
+        const project = projectById.get(row.wbsElementId);
+        const spi = project?.spi ?? null;
+        switch (indexBand(spi)) {
+          case "Red":
+            return c.error;
+          case "Amber":
+            return c.warning;
+          case "Green":
+            return c.success;
+          default:
+            // Unknown (SPI null) — muted so undated-progress projects recede.
+            return c.textSecondary;
+        }
+      },
+    [projectById],
+  );
+
+  // Tooltip: project name (bold), status, formatted date range, CPI/SPI.
+  const tooltipFormatter = useMemo(
+    () =>
+      (row: GanttRow, _currency: string, c: EChartsColorPalette): string => {
+        const project = projectById.get(row.wbsElementId);
+        const start = row.startDate!;
+        const end = row.endDate!;
+        const durationDays = Math.ceil(
+          (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        const statusLine = project
+          ? `<div style="color:${c.textSecondary};font-size:11px;margin-bottom:4px;">${project.status.replace(/_/g, " ")}</div>`
+          : "";
+        const cpiLine =
+          project && project.cpi != null
+            ? `<div style="display:flex;justify-content:space-between;gap:24px;"><span>CPI</span><span style="font-weight:600;">${formatValue(project.cpi, "number")}</span></div>`
+            : "";
+        const spiLine =
+          project && project.spi != null
+            ? `<div style="display:flex;justify-content:space-between;gap:24px;"><span>SPI</span><span style="font-weight:600;">${formatValue(project.spi, "number")}</span></div>`
+            : "";
+        return `<div style="font-weight:600;margin-bottom:4px;">${row.name}</div>
+${statusLine}<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>Start</span><span style="font-weight:600;">${formatDate(start)}</span>
+</div>
+<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>End</span><span style="font-weight:600;">${formatDate(end)}</span>
+</div>
+<div style="display:flex;justify-content:space-between;gap:24px;">
+  <span>Duration</span><span style="font-weight:600;">${durationDays} days</span>
+</div>
+${cpiLine}${spiLine}`;
+      },
+    [projectById],
+  );
+
+  return (
+    <WidgetShell
+      instanceId={instanceId}
+      title="Portfolio Timeline"
+      icon={<BarChartOutlined />}
+      isEditing={isEditing}
+      isLoading={isLoading}
+      error={error}
+      onRemove={onRemove}
+      onRefresh={refetch}
+      onConfigure={onConfigure}
+      onFullscreen={onFullscreen}
+      widgetType={widgetType}
+      dashboardName={dashboardName}
+    >
+      {rows.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={
+            <Text type="secondary">No projects with start/end dates</Text>
+          }
+        />
+      ) : (
+        <ScheduleTimeline
+          rows={rows}
+          config={defaultCompactConfig}
+          barColorFor={barColorFor}
+          tooltipFormatter={tooltipFormatter}
+          colors={colors}
+          currency={PORTFOLIO_CURRENCY}
+          tooltipConfig={tooltipConfig}
+          height="100%"
+          loading={isLoading}
+        />
+      )}
+    </WidgetShell>
+  );
+};
+
+registerWidget<PortfolioGanttConfig>({
+  typeId: widgetTypeId("portfolio-gantt"),
+  displayName: "Portfolio Timeline",
+  description:
+    "Gantt of all projects' start→end spans, coloured by schedule RAG (SPI).",
+  category: "schedule",
+  icon: <BarChartOutlined />,
+  sizeConstraints: {
+    minW: 4,
+    minH: 3,
+    defaultW: 6,
+    defaultH: 4,
+  },
+  scope: "portfolio",
+  requiredPermission: "portfolio-read",
+  component: PortfolioGanttComponent,
+  defaultConfig: {},
+});

--- a/frontend/src/features/widgets/definitions/__tests__/portfolioGanttWidget.test.tsx
+++ b/frontend/src/features/widgets/definitions/__tests__/portfolioGanttWidget.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * Phase 4 render tests for the Portfolio Timeline (portfolio-gantt) widget.
+ *
+ * Mirrors `portfolioWidgets.test.tsx` (mock `usePortfolioEVM` + the
+ * DashboardContextBus harness). Because the Gantt bars render on an ECharts
+ * canvas (not the DOM), the row-count / skip / filter assertions spy on the
+ * engine entry — `buildGanttOptions` — and read the `rows` array it receives.
+ * That captures the widget's row model without depending on canvas rendering.
+ *
+ * Design doc §7 Phase 4 verify: portfolio-gantt renders one bar per project
+ * that has BOTH start+end dates, skips projects missing either, honours the
+ * portfolio status/RAG filter, and registers with scope:'portfolio' +
+ * requiredPermission:'portfolio-read'.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { App as AntdApp } from "antd";
+import type { ReactNode } from "react";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+//
+// `DashboardContextBus` consumes TimeMachineContext internally; mock it the same
+// way portfolioWidgets.test.tsx does.
+vi.mock("@/contexts/TimeMachineContext", () => ({
+  useTimeMachine: () => ({
+    asOf: undefined,
+    branch: "main",
+    mode: "merged",
+    isHistorical: false,
+    invalidateQueries: vi.fn(),
+  }),
+}));
+
+const usePortfolioEVMMock = vi.fn();
+vi.mock("@/features/portfolio/api/usePortfolioEVM", () => ({
+  usePortfolioEVM: () => usePortfolioEVMMock(),
+}));
+
+// Spy on the Gantt engine entry. ScheduleTimeline imports buildGanttOptions by
+// name from this path, so the mock intercepts it and captures the rows array.
+// vi.hoisted is required because vi.mock factories are hoisted above top-level
+// const declarations — the spy must exist at hoist time.
+const { buildGanttOptionsMock } = vi.hoisted(() => ({
+  buildGanttOptionsMock: vi.fn(() => ({ series: [], xAxis: [], yAxis: [] })),
+}));
+vi.mock("@/features/schedule-baselines/components/GanttChart/GanttChartOptions", () => ({
+  buildGanttOptions: buildGanttOptionsMock,
+  // defaultGanttTooltip is exported by the options module; not needed here but
+  // kept to satisfy any transitive import shape.
+  defaultGanttTooltip: vi.fn(),
+}));
+
+// useEChartsTheme returns token values used for bar colour + tooltip; return a
+// minimal valid palette so the widget's barColorFor resolves real tokens.
+vi.mock("@/features/evm/utils/echartsTheme", () => ({
+  useEChartsTheme: () => ({
+    colors: {
+      primary: "#1677ff",
+      success: "#52c41a",
+      warning: "#faad14",
+      error: "#ff4d4f",
+      info: "#1677ff",
+      pv: "#5b8ff9",
+      ev: "#5ad8a6",
+      ac: "#5d7092",
+      forecast: "#faad14",
+      actual: "#ff4d4f",
+      gaugeGood: "#52c41a",
+      gaugeWarning: "#faad14",
+      gaugeBad: "#ff4d4f",
+      text: "#000",
+      textSecondary: "#8c8c8c",
+      border: "#d9d9d9",
+      bg: "#fff",
+    },
+    tooltipConfig: {
+      backgroundColor: "#fff",
+      borderColor: "#d9d9d9",
+      borderWidth: 1,
+      textStyle: { color: "#000", fontSize: 12 },
+      padding: [8, 12],
+      extraCssText: "",
+    },
+  }),
+}));
+
+// Import the definitions AFTER mocks are registered so the registry picks up
+// the side-effecting registerWidget() calls via registerAll.
+import "@/features/widgets/definitions/registerAll";
+import { getWidgetDefinition, getAllWidgetDefinitions } from "../..";
+import { widgetTypeId } from "../../types";
+import { DashboardContextBus } from "../../context/DashboardContextBus";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Build a portfolio project with the given id, name, dates, and EVM. */
+function project(opts: {
+  id: string;
+  name: string;
+  start?: string | null;
+  end?: string | null;
+  status?: string;
+  cpi?: number | null;
+  spi?: number | null;
+}) {
+  return {
+    project_id: opts.id,
+    name: opts.name,
+    status: opts.status ?? "active",
+    cpi: opts.cpi ?? null,
+    spi: opts.spi ?? null,
+    vac: 0,
+    contract_value: 1000,
+    bac: 1000,
+    currency: "EUR",
+    at_risk: false,
+    start_date: opts.start === undefined ? "2025-01-01" : opts.start,
+    end_date: opts.end === undefined ? "2025-06-01" : opts.end,
+  };
+}
+
+function setPortfolioEVM(projects: ReturnType<typeof project>[]) {
+  usePortfolioEVMMock.mockReturnValue({
+    data: {
+      summary: { cpi: 1.0, spi: 1.0, vac: 0, tcpi: 1.0 },
+      projects,
+      at_risk_projects: [],
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+}
+
+/** Portfolio-scope harness: real context provider with projectId="" + filter. */
+function renderInPortfolio(
+  ui: ReactNode,
+  portfolioFilter: {
+    controlDate: string | null;
+    status: string[] | null;
+    rag: string[] | null;
+  } = { controlDate: null, status: null, rag: null },
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AntdApp>
+          <DashboardContextBus
+            scope="portfolio"
+            portfolioFilter={portfolioFilter}
+          >
+            {children}
+          </DashboardContextBus>
+        </AntdApp>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+
+  return render(<div style={{ height: 400 }}>{ui}</div>, { wrapper: Wrapper });
+}
+
+/** Look up the widget's render component and invoke it directly. */
+function renderWidget(typeIdStr: string, config: Record<string, unknown>) {
+  const def = getWidgetDefinition(widgetTypeId(typeIdStr));
+  if (!def) throw new Error(`widget ${typeIdStr} not registered`);
+  const Component = def.component;
+  return renderInPortfolio(
+    <Component config={config} instanceId="inst-1" isEditing={false} onRemove={vi.fn()} />,
+  );
+}
+
+/** Read the most recent rows array passed to the mocked buildGanttOptions. */
+function lastRows(): unknown[] {
+  const calls = buildGanttOptionsMock.mock.calls;
+  if (calls.length === 0) return [];
+  // calls is a variadic tuple; cast through unknown to read the first arg
+  // (the rows array) without asserting a fixed-length tuple shape.
+  return (calls[calls.length - 1] as unknown[])[0] as unknown[];
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("PortfolioGanttWidget — registry", () => {
+  it("registers portfolio-gantt with scope:'portfolio' + requiredPermission:'portfolio-read'", () => {
+    const def = getWidgetDefinition(widgetTypeId("portfolio-gantt"));
+    expect(def, "portfolio-gantt must be registered").toBeDefined();
+    expect(def?.scope).toBe("portfolio");
+    expect(def?.requiredPermission).toBe("portfolio-read");
+  });
+
+  it("the registry now holds 26 definitions (21 project + 5 portfolio)", () => {
+    expect(getAllWidgetDefinitions()).toHaveLength(26);
+  });
+});
+
+describe("PortfolioGanttWidget — row model", () => {
+  beforeEach(() => {
+    usePortfolioEVMMock.mockReset();
+    buildGanttOptionsMock.mockClear();
+  });
+
+  it("renders one bar per project that has BOTH start_date and end_date", () => {
+    setPortfolioEVM([
+      project({ id: "p1", name: "Alpha", start: "2025-01-01", end: "2025-03-01" }),
+      project({ id: "p2", name: "Beta", start: "2025-02-01", end: "2025-04-01" }),
+    ]);
+    renderWidget("portfolio-gantt", {});
+
+    expect(lastRows()).toHaveLength(2);
+    expect(lastRows().map((r) => (r as { name: string }).name)).toEqual(
+      expect.arrayContaining(["Alpha", "Beta"]),
+    );
+  });
+
+  it("skips a project whose start_date OR end_date is null", () => {
+    setPortfolioEVM([
+      project({ id: "p1", name: "Dated", start: "2025-01-01", end: "2025-03-01" }),
+      project({ id: "p2", name: "NoStart", start: null, end: "2025-03-01" }),
+      project({ id: "p3", name: "NoEnd", start: "2025-01-01", end: null }),
+      project({ id: "p4", name: "BothNull", start: null, end: null }),
+    ]);
+    renderWidget("portfolio-gantt", {});
+
+    const names = lastRows().map((r) => (r as { name: string }).name);
+    expect(names).toEqual(["Dated"]);
+  });
+
+  it("narrowing the portfolio status filter removes the project's bar", () => {
+    setPortfolioEVM([
+      project({ id: "p1", name: "Active", status: "active" }),
+      project({ id: "p2", name: "Completed", status: "completed" }),
+    ]);
+
+    // Re-render with a status filter that excludes "active" → only Completed remains.
+    const def = getWidgetDefinition(widgetTypeId("portfolio-gantt"))!;
+    const Component = def.component;
+    renderInPortfolio(
+      <Component config={{}} instanceId="inst-1" isEditing={false} onRemove={vi.fn()} />,
+      { controlDate: null, status: ["completed"], rag: null },
+    );
+
+    const names = lastRows().map((r) => (r as { name: string }).name);
+    expect(names).toEqual(["Completed"]);
+    expect(names).not.toContain("Active");
+  });
+
+  it("sorts the bars ascending by start date", () => {
+    setPortfolioEVM([
+      project({ id: "p1", name: "Late", start: "2025-06-01", end: "2025-09-01" }),
+      project({ id: "p2", name: "Early", start: "2025-01-01", end: "2025-03-01" }),
+      project({ id: "p3", name: "Mid", start: "2025-03-01", end: "2025-05-01" }),
+    ]);
+    renderWidget("portfolio-gantt", {});
+
+    const names = lastRows().map((r) => (r as { name: string }).name);
+    expect(names).toEqual(["Early", "Mid", "Late"]);
+  });
+
+  it("renders the empty-state placeholder when no projects have dates", () => {
+    setPortfolioEVM([
+      project({ id: "p1", name: "Undated", start: null, end: null }),
+    ]);
+    const { getByText } = renderWidget("portfolio-gantt", {});
+
+    expect(getByText("No projects with start/end dates")).toBeInTheDocument();
+    // Engine never invoked when there are no rows.
+    expect(buildGanttOptionsMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/widgets/definitions/__tests__/portfolioWidgets.test.tsx
+++ b/frontend/src/features/widgets/definitions/__tests__/portfolioWidgets.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Phase 4 render tests for the 4 portfolio-scope widgets.
+ * Phase 4 render tests for the 5 portfolio-scope widgets.
  *
  * Each widget is rendered inside a portfolio-scope `DashboardContextBus` (so
  * `scope` + `portfolioFilter` flow through the real context, matching how the
@@ -186,16 +186,17 @@ describe("portfolio widgets — registry", () => {
     setPortfolioCO();
   });
 
-  it("registers exactly 25 widget definitions (21 project + 4 portfolio)", () => {
-    expect(getAllWidgetDefinitions()).toHaveLength(25);
+  it("registers exactly 26 widget definitions (21 project + 5 portfolio)", () => {
+    expect(getAllWidgetDefinitions()).toHaveLength(26);
   });
 
-  it("registers all 4 portfolio widgets with scope:'portfolio'", () => {
+  it("registers all 5 portfolio widgets with scope:'portfolio'", () => {
     const portfolioIds = [
       "portfolio-kpi",
       "portfolio-projects-table",
       "portfolio-co-pipeline",
       "portfolio-distress-list",
+      "portfolio-gantt",
     ];
     for (const id of portfolioIds) {
       const def = getWidgetDefinition(widgetTypeId(id));
@@ -204,12 +205,13 @@ describe("portfolio widgets — registry", () => {
     }
   });
 
-  it("all 4 portfolio widgets gate on portfolio-read (F-7/G14: portfolio-co-pipeline matches its data route)", () => {
+  it("all 5 portfolio widgets gate on portfolio-read (F-7/G14: portfolio-co-pipeline matches its data route)", () => {
     for (const id of [
       "portfolio-kpi",
       "portfolio-projects-table",
       "portfolio-co-pipeline",
       "portfolio-distress-list",
+      "portfolio-gantt",
     ]) {
       expect(
         getWidgetDefinition(widgetTypeId(id))?.requiredPermission,

--- a/frontend/src/features/widgets/definitions/__tests__/widgetPermissions.mapping.test.ts
+++ b/frontend/src/features/widgets/definitions/__tests__/widgetPermissions.mapping.test.ts
@@ -1,5 +1,5 @@
 /**
- * Phase 9 — canonical required-permission + scope mapping for ALL 25 widgets.
+ * Phase 9 — canonical required-permission + scope mapping for ALL 26 widgets.
  *
  * This is the drift-detection source of truth. Every widget's
  * `requiredPermission` + `scope` is asserted here against the CORRECTED §6
@@ -7,7 +7,7 @@
  * changes either field on any widget (or adds/removes a widget) will break a
  * focused assertion, forcing an explicit, reviewed update to this table.
  *
- * The 4 portfolio widgets are also covered by `portfolioWidgets.test.tsx`
+ * The 5 portfolio widgets are also covered by `portfolioWidgets.test.tsx`
  * (render-focused); this file is the single exhaustive mapping assertion.
  *
  * Design doc: docs/03-project-plan/iterations/2026-06-29-global-dashboard-widgets/
@@ -92,7 +92,7 @@ const EXPECTATIONS: Array<{
     requiredPermission: "cost-event-read",
   },
 
-  // ── 4 portfolio-scope widgets ───────────────────────────────────────────
+  // ── 5 portfolio-scope widgets ───────────────────────────────────────────
   { typeId: "portfolio-kpi", scope: "portfolio", requiredPermission: "portfolio-read" },
   {
     typeId: "portfolio-projects-table",
@@ -109,17 +109,18 @@ const EXPECTATIONS: Array<{
     scope: "portfolio",
     requiredPermission: "portfolio-read",
   },
+  { typeId: "portfolio-gantt", scope: "portfolio", requiredPermission: "portfolio-read" },
 ];
 
 describe("widget permission + scope mapping (Phase 9, §6 corrected)", () => {
-  it("covers exactly the 25 known widgets (21 project + 4 portfolio)", () => {
-    expect(EXPECTATIONS).toHaveLength(25);
+  it("covers exactly the 26 known widgets (21 project + 5 portfolio)", () => {
+    expect(EXPECTATIONS).toHaveLength(26);
     expect(EXPECTATIONS.filter((e) => e.scope === "project")).toHaveLength(21);
-    expect(EXPECTATIONS.filter((e) => e.scope === "portfolio")).toHaveLength(4);
+    expect(EXPECTATIONS.filter((e) => e.scope === "portfolio")).toHaveLength(5);
 
-    // Registry itself must hold exactly these 25 (catches duplicate/extra
+    // Registry itself must hold exactly these 26 (catches duplicate/extra
     // registerWidget calls introduced alongside a mapping drift).
-    expect(getAllWidgetDefinitions()).toHaveLength(25);
+    expect(getAllWidgetDefinitions()).toHaveLength(26);
   });
 
   it("has no duplicate typeIds in the expectation table", () => {

--- a/frontend/src/features/widgets/definitions/registerAll.ts
+++ b/frontend/src/features/widgets/definitions/registerAll.ts
@@ -32,6 +32,7 @@ import "./PortfolioKpiWidget";
 import "./PortfolioProjectsTableWidget";
 import "./PortfolioChangeOrderPipelineWidget";
 import "./PortfolioDistressListWidget";
+import "./PortfolioGanttWidget";
 
 export function registerAllWidgets() {
   // Widgets are registered via module-level side effects on import.

--- a/frontend/src/features/widgets/types.ts
+++ b/frontend/src/features/widgets/types.ts
@@ -41,6 +41,7 @@ export function widgetTypeId(id: string): WidgetTypeId {
  * - **diagnostic**: Variance analysis, root-cause views
  * - **breakdown**: Structured drilldowns (WBS tree, cost element grids)
  * - **action**: Action-oriented lists (pending approvals, recent entries)
+ * - **schedule**: Timeline / Gantt views (project + portfolio spans)
  * - **settings**: Configuration widgets for project-specific settings
  */
 export type WidgetCategory =
@@ -49,6 +50,7 @@ export type WidgetCategory =
   | "diagnostic"
   | "breakdown"
   | "action"
+  | "schedule"
   | "settings";
 
 /**

--- a/frontend/src/pages/control-accounts/ControlAccountOverview.tsx
+++ b/frontend/src/pages/control-accounts/ControlAccountOverview.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { useParams, useNavigate, useOutletContext } from "react-router-dom";
 import { useState } from "react";
-import { Button, Card, Descriptions, Table, Tag, Grid } from "antd";
-import { HistoryOutlined } from "@ant-design/icons";
+import { Button, Descriptions, Table, Tag, Grid } from "antd";
+import { HistoryOutlined, InfoCircleOutlined, ProfileOutlined } from "@ant-design/icons";
+import { PanelCard } from "@/components/common/PanelCard";
 import { useWorkPackages } from "@/features/work-packages/api/useWorkPackages";
 import { useWBSElement } from "@/features/wbs-elements/api/useWBSElements";
 import { formatCurrency } from "@/utils/formatters";
@@ -62,7 +63,10 @@ export const ControlAccountOverview: React.FC = () => {
   return (
     <PageContent>
       {/* Control Account Information */}
-      <Card title="Control Account Information">
+      <PanelCard
+        icon={<InfoCircleOutlined />}
+        title="Control Account Information"
+      >
         <Descriptions
           column={1}
           size="middle"
@@ -109,10 +113,13 @@ export const ControlAccountOverview: React.FC = () => {
             },
           ]}
         />
-      </Card>
+      </PanelCard>
 
       {/* Work Packages Table */}
-      <Card title="Work Packages">
+      <PanelCard
+        icon={<ProfileOutlined />}
+        title="Work Packages"
+      >
         <Table
           dataSource={workPackages}
           rowKey="work_package_id"
@@ -167,7 +174,7 @@ export const ControlAccountOverview: React.FC = () => {
             },
           ]}
         />
-      </Card>
+      </PanelCard>
 
       {/* Control Account metadata footer — standardized across entity pages */}
       {ca && (

--- a/frontend/src/pages/control-accounts/ControlAccountOverview.tsx
+++ b/frontend/src/pages/control-accounts/ControlAccountOverview.tsx
@@ -64,7 +64,7 @@ export const ControlAccountOverview: React.FC = () => {
       {/* Control Account Information */}
       <Card title="Control Account Information">
         <Descriptions
-          column={isMobile ? 1 : 2}
+          column={1}
           size="middle"
           bordered
           items={[

--- a/frontend/src/pages/cost-elements/CostElementOverview.tsx
+++ b/frontend/src/pages/cost-elements/CostElementOverview.tsx
@@ -41,7 +41,7 @@ export const CostElementOverview = () => {
   return (
     <>
       <Card title="Cost Element Details" size="small">
-        <Descriptions column={2} bordered size="small">
+        <Descriptions column={1} bordered size="small">
           <Descriptions.Item label="Type">
             {typeName}
           </Descriptions.Item>

--- a/frontend/src/pages/cost-elements/CostElementOverview.tsx
+++ b/frontend/src/pages/cost-elements/CostElementOverview.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { useParams } from "react-router-dom";
-import { Button, Card, Descriptions } from "antd";
-import { HistoryOutlined } from "@ant-design/icons";
+import { Button, Descriptions } from "antd";
+import { HistoryOutlined, InfoCircleOutlined } from "@ant-design/icons";
+import { PanelCard } from "@/components/common/PanelCard";
 import { useCostElement } from "@/features/cost-elements/api/useCostElements";
 import { useCostElementTypes } from "@/features/cost-elements/api/useCostElementTypes";
 import { EntityMetadataCard } from "@/components/common/EntityMetadataCard";
@@ -40,7 +41,10 @@ export const CostElementOverview = () => {
 
   return (
     <>
-      <Card title="Cost Element Details" size="small">
+      <PanelCard
+        icon={<InfoCircleOutlined />}
+        title="Cost Element Details"
+      >
         <Descriptions column={1} bordered size="small">
           <Descriptions.Item label="Type">
             {typeName}
@@ -49,7 +53,7 @@ export const CostElementOverview = () => {
             {costElement.description || "-"}
           </Descriptions.Item>
         </Descriptions>
-      </Card>
+      </PanelCard>
 
       <EntityMetadataCard
         entityId={costElement.cost_element_id}

--- a/frontend/src/pages/projects/ProjectOverview.tsx
+++ b/frontend/src/pages/projects/ProjectOverview.tsx
@@ -10,8 +10,9 @@ import { WBSElementTable } from "@/components/hierarchy/WBSElementTable";
 import { WBSElementCreate, WBSElementRead, ProjectUpdate } from "@/api/generated";
 import { useProjectBudgetStatus } from "@/features/cost-registration/api/useCostRegistrations";
 import type { Version } from "@/components/common/VersionHistory";
-import { Button, Skeleton, Card, theme, Space, Grid } from "antd";
-import { PlusOutlined, EditOutlined, HistoryOutlined, DeleteOutlined } from "@ant-design/icons";
+import { Button, Skeleton, theme, Space, Grid } from "antd";
+import { PlusOutlined, EditOutlined, HistoryOutlined, DeleteOutlined, ApartmentOutlined } from "@ant-design/icons";
+import { PanelCard } from "@/components/common/PanelCard";
 import { useState } from "react";
 import { WBSElementModal } from "@/features/wbs-elements/components/WBSElementModal";
 import { DeleteProjectModal } from "@/components/projects/DeleteProjectModal";
@@ -177,7 +178,8 @@ export const ProjectOverview = () => {
           />
 
           {/* Root WBEs */}
-          <Card
+          <PanelCard
+            icon={<ApartmentOutlined />}
             title="Root WBS Elements"
             style={{ marginBottom: token.marginLG }}
             styles={{ body: { padding: `${token.paddingSM}px 0` } }}
@@ -203,7 +205,7 @@ export const ProjectOverview = () => {
               variant={resolvedMode}
               currency={project.currency}
             />
-          </Card>
+          </PanelCard>
 
           {/* Project metadata footer — standardized across entity pages */}
           <EntityMetadataCard

--- a/frontend/src/pages/projects/change-orders/ChangeOrderUnifiedPage.tsx
+++ b/frontend/src/pages/projects/change-orders/ChangeOrderUnifiedPage.tsx
@@ -180,7 +180,11 @@ export function ChangeOrderUnifiedPage(): JSX.Element {
                 children: (
                   <CollapsibleCard
                     id="approval-info"
-                    title={<span>Approval Information</span>}
+                    title={
+                      <span style={{ fontSize: token.fontSizeLG, fontWeight: token.fontWeightStrong, color: token.colorText }}>
+                        Approval Information
+                      </span>
+                    }
                     collapsed={false}
                   >
                     <ApprovalInfo

--- a/frontend/src/pages/wbs-elements/WBSElementOverview.tsx
+++ b/frontend/src/pages/wbs-elements/WBSElementOverview.tsx
@@ -1,7 +1,8 @@
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { useState, useMemo, useEffect, useRef } from "react";
-import { App, Button, Card, Space, Grid, Table, Tag, Empty, Spin, theme } from "antd";
-import { EditOutlined, DeleteOutlined, PlusOutlined, HistoryOutlined } from "@ant-design/icons";
+import { App, Button, Space, Grid, Table, Tag, Empty, Spin, theme } from "antd";
+import { EditOutlined, DeleteOutlined, PlusOutlined, HistoryOutlined, ApartmentOutlined, ClusterOutlined, ProfileOutlined } from "@ant-design/icons";
+import { PanelCard } from "@/components/common/PanelCard";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import {
   useWBSElement,
@@ -227,7 +228,8 @@ export const WBSElementOverview = () => {
         )}
 
         {/* Child WBEs Section */}
-        <Card
+        <PanelCard
+          icon={<ApartmentOutlined />}
           title="Child WBS Elements"
           extra={
             <Space>
@@ -246,13 +248,14 @@ export const WBSElementOverview = () => {
             onRowClick={handleRowClick}
             variant={resolvedMode}
           />
-        </Card>
+        </PanelCard>
 
         {/* Cost Elements are now managed under Work Packages */}
 
         {/* Control Accounts Section */}
-        <Card
+        <PanelCard
           ref={caSectionRef}
+          icon={<ClusterOutlined />}
           title="Control Accounts"
           extra={
             <Space>
@@ -322,10 +325,11 @@ export const WBSElementOverview = () => {
               />
             );
           })()}
-        </Card>
+        </PanelCard>
 
         {/* Work Packages Section */}
-        <Card
+        <PanelCard
+          icon={<ProfileOutlined />}
           title="Work Packages"
           extra={
             <Space>
@@ -416,7 +420,7 @@ export const WBSElementOverview = () => {
               />
             );
           })()}
-        </Card>
+        </PanelCard>
 
         {/* WBS Element metadata footer — standardized across entity pages */}
         {wbe && (

--- a/frontend/src/pages/work-packages/WorkPackageOverview.tsx
+++ b/frontend/src/pages/work-packages/WorkPackageOverview.tsx
@@ -308,7 +308,7 @@ export const WorkPackageOverview = () => {
 
       {/* Section 2: Schedule Baseline + Forecast side-by-side on desktop */}
       <Row gutter={[token.marginLG, token.marginLG]}>
-        <Col xs={24} lg={12}>
+        <Col xs={24} xl={12}>
           <Card
             title={
               <Space>
@@ -357,7 +357,7 @@ export const WorkPackageOverview = () => {
             }
           >
             {scheduleBaseline ? (
-              <Descriptions column={{ xs: 1, sm: 2 }} size="small">
+              <Descriptions column={1} size="small">
                 <Descriptions.Item label="Name">
                   <Text strong>{scheduleBaseline.name}</Text>
                 </Descriptions.Item>
@@ -386,7 +386,7 @@ export const WorkPackageOverview = () => {
           </Card>
         </Col>
 
-        <Col xs={24} lg={12}>
+        <Col xs={24} xl={12}>
           <Card
             title={
               <Space>
@@ -435,7 +435,7 @@ export const WorkPackageOverview = () => {
             }
           >
             {forecast ? (
-              <Descriptions column={{ xs: 1, sm: 2 }} size="small">
+              <Descriptions column={1} size="small">
                 <Descriptions.Item label="Estimate at Complete (EAC)">
                   <Text strong>
                     {formatCurrency(Number(forecast.eac_amount || 0), currency)}

--- a/frontend/src/pages/work-packages/WorkPackageOverview.tsx
+++ b/frontend/src/pages/work-packages/WorkPackageOverview.tsx
@@ -1,6 +1,5 @@
 import { useParams } from "react-router-dom";
 import {
-  Card,
   Descriptions,
   Typography,
   theme,
@@ -14,7 +13,6 @@ import {
   Tag,
   Grid,
   Space,
-  Flex,
   Divider,
 } from "antd";
 import {
@@ -27,6 +25,8 @@ import {
   PieChartOutlined,
   HistoryOutlined,
 } from "@ant-design/icons";
+import { PanelCard } from "@/components/common/PanelCard";
+import { entityInfoDescriptionsProps } from "@/components/common/entityInfoDescriptionsProps";
 import { ViewModeToggle } from "@/components/common/ViewModeToggle";
 import { useViewMode } from "@/hooks/useViewMode";
 import { CostElementCard } from "@/features/cost-elements/components/CostElementCard";
@@ -309,14 +309,9 @@ export const WorkPackageOverview = () => {
       {/* Section 2: Schedule Baseline + Forecast side-by-side on desktop */}
       <Row gutter={[token.marginLG, token.marginLG]}>
         <Col xs={24} xl={12}>
-          <Card
-            title={
-              <Space>
-                <CalendarOutlined />
-                <span>Schedule Baseline</span>
-              </Space>
-            }
-            size="small"
+          <PanelCard
+            icon={<CalendarOutlined />}
+            title="Schedule Baseline"
             extra={
               <Space>
                 {scheduleBaseline ? (
@@ -357,7 +352,7 @@ export const WorkPackageOverview = () => {
             }
           >
             {scheduleBaseline ? (
-              <Descriptions column={1} size="small">
+              <Descriptions {...entityInfoDescriptionsProps(token)}>
                 <Descriptions.Item label="Name">
                   <Text strong>{scheduleBaseline.name}</Text>
                 </Descriptions.Item>
@@ -383,18 +378,13 @@ export const WorkPackageOverview = () => {
                 No schedule baseline defined. Add one to enable Planned Value calculations and EVM analysis.
               </Text>
             )}
-          </Card>
+          </PanelCard>
         </Col>
 
         <Col xs={24} xl={12}>
-          <Card
-            title={
-              <Space>
-                <LineChartOutlined />
-                <span>Forecast</span>
-              </Space>
-            }
-            size="small"
+          <PanelCard
+            icon={<LineChartOutlined />}
+            title="Forecast"
             extra={
               <Space>
                 {forecast ? (
@@ -435,7 +425,7 @@ export const WorkPackageOverview = () => {
             }
           >
             {forecast ? (
-              <Descriptions column={1} size="small">
+              <Descriptions {...entityInfoDescriptionsProps(token)}>
                 <Descriptions.Item label="Estimate at Complete (EAC)">
                   <Text strong>
                     {formatCurrency(Number(forecast.eac_amount || 0), currency)}
@@ -476,24 +466,22 @@ export const WorkPackageOverview = () => {
                 No forecast defined. Add one to track Estimate at Complete (EAC) and Variance at Complete (VAC).
               </Text>
             )}
-          </Card>
+          </PanelCard>
         </Col>
       </Row>
 
       {/* Section 3: Budget Summary */}
       {!budgetLoading && (
         <>
-          <Card size="small">
-            <Flex justify="space-between" align="center" style={{ marginBottom: token.marginMD }}>
-              <Space>
-                <DollarOutlined style={{ color: token.colorPrimary }} />
-                <Text strong style={{ fontSize: token.fontSizeLG }}>Budget Summary</Text>
-              </Space>
+          <PanelCard
+            icon={<DollarOutlined />}
+            title="Budget Summary"
+            extra={
               <Tag color={percentage >= 100 ? "red" : percentage >= 90 ? "orange" : "blue"}>
                 {statusText}
               </Tag>
-            </Flex>
-
+            }
+          >
             <Row gutter={[token.marginMD, token.marginMD]}>
               <Col xs={12} sm={6}>
                 <Statistic
@@ -546,7 +534,7 @@ export const WorkPackageOverview = () => {
               strokeColor={statusColor}
               status={percentage >= 100 ? "exception" : undefined}
             />
-          </Card>
+          </PanelCard>
 
           {(percentage >= 100 || (percentage >= 90 && percentage < 100)) && (
             <Alert
@@ -564,14 +552,9 @@ export const WorkPackageOverview = () => {
       )}
 
       {/* Section 4: Cost Elements (EOC) */}
-      <Card
-        title={
-          <Space>
-            <PieChartOutlined />
-            <span>Cost Elements</span>
-          </Space>
-        }
-        size="small"
+      <PanelCard
+        icon={<PieChartOutlined />}
+        title="Cost Elements"
         extra={
           <Space>
             <ViewModeToggle viewMode={ceViewMode} onCycleViewMode={ceCycleViewMode} />
@@ -616,7 +599,7 @@ export const WorkPackageOverview = () => {
             />
           );
         })()}
-      </Card>
+      </PanelCard>
 
       {/* Work Package metadata footer — standardized across entity pages */}
       <EntityMetadataCard


### PR DESCRIPTION
## Summary

Fast-forwards `main` to `develop` — **14 commits, 50 files, +1716/−234** (develop is **0 behind / 14 ahead**, so this is a clean, conflict-free merge). This is the broad trunk integration since the last main update, spanning a new portfolio widget, a sweep of dashboard/EVM/COQ reactivity fixes, the entity-panel UI standardization, and the marketing-site deploy.

## What's included

**📈 Portfolio Gantt widget**
- New Portfolio Gantt widget (project start/end timeline) + portfolio EVM fixes (coerce naive `as_of` to UTC; dedup portfolio EVM project rows).

**🔄 Dashboard widget reactivity (as-of / branch / branch-mode)**
- EVM widgets refresh on branch-mode change.
- Change-orders & cost-registrations refresh on branch/mode change.
- COQ widgets refresh on as-of change.

**🔧 EVM / COQ correctness**
- Compute WBS descendants in merged mode on change-order branches.
- Return empty metrics with a warning when `control_date` precedes the entity version (no more 500/error).
- Apply `as_of` in `coq-metrics`.

**🎨 Entity-panel UI standardization + responsiveness**
- Adopt the canonical `PanelCard` wrapper across all entity overview/detail panels (Project, WBS, Work Package, Cost Element, Control Account, Change Order) + explorer cards. `PanelCard` bakes in the detail-panel header padding so titles/action buttons have consistent breathing room against the borders, while bodies stay compact.
- Single-column "one info per row" detail `Descriptions` (via the shared `entityInfoDescriptionsProps` + standalone panels) to stop label/value cramping at low horizontal resolutions.
- Work Package schedule/forecast cards stack full-width below `xl` (1200px).

**🛠 Other**
- `merge: bring custom-fields (system-admin CO config fix) into develop` — the CO-config portion of the custom-fields initiative.
- System-admin: pick the populated global CO config in `dump_database`.
- Deploy: serve the marketing website at `www.backcast.duckdns.org`.

## Merge notes

- **Clean fast-forward** (0 behind `main`) — no merge commit, no conflicts expected.
- Overlaps on a few files with **PR #105 (`custom-fields → main`)**, which carries the full custom-fields feature (Phases 0–3). Whichever merges first, the other will need a rebase; the CO-config fix included here is the subset already merged into `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
